### PR TITLE
Add const getters of storage and resource in registry

### DIFF
--- a/src/ecstasy/registry/Registry.cpp
+++ b/src/ecstasy/registry/Registry.cpp
@@ -35,6 +35,16 @@ namespace ecstasy
         return EntityBuilder(*this);
     }
 
+    const Entities &Registry::getEntities() const
+    {
+        return getResource<Entities>();
+    }
+
+    Entities &Registry::getEntities()
+    {
+        return getResource<Entities>();
+    }
+
     Entity Registry::getEntity(Entity::Index index) noexcept
     {
         return getResource<Entities>().get(index);

--- a/src/ecstasy/registry/Registry.hpp
+++ b/src/ecstasy/registry/Registry.hpp
@@ -186,6 +186,24 @@ namespace ecstasy
         ///
         /// @tparam R Type of the resource to fetch.
         ///
+        /// @return const R& Const reference to an instance of type @b R.
+        ///
+        /// @throw std::logic_error If the resource @b R was not present in the registry.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-10-18)
+        ///
+        template <std::derived_from<Resource> R>
+        const R &getResource() const
+        {
+            return _resources.get<R>();
+        }
+
+        ///
+        /// @brief Get the Resource of type @b R.
+        ///
+        /// @tparam R Type of the resource to fetch.
+        ///
         /// @return R& Reference to an instance of type @b R.
         ///
         /// @throw std::logic_error If the resource @b R was not present in the registry.
@@ -197,6 +215,24 @@ namespace ecstasy
         R &getResource()
         {
             return _resources.get<R>();
+        }
+
+        ///
+        /// @brief Get the Storage for the component type @b C.
+        ///
+        /// @tparam C Type of the component for which we want the storage.
+        ///
+        /// @return getStorageType<C>& Const reference to the storage of the component type @b C.
+        ///
+        /// @throw std::logic_error If no storage for component @b C was found in the registry.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-10-18)
+        ///
+        template <typename C>
+        const getStorageType<C> &getStorage() const
+        {
+            return _storages.get<getStorageType<C>>();
         }
 
         ///
@@ -234,6 +270,30 @@ namespace ecstasy
                 addStorage<C>();
             return _storages.get<getStorageType<C>>();
         }
+
+        ///
+        /// @brief Get the Entities resource.
+        ///
+        /// @return const Entities& Const reference to the @ref Entities resource.
+        ///
+        /// @throw std::logic_error If the resource is not found.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-10-21)
+        ///
+        const Entities &getEntities() const;
+
+        ///
+        /// @brief Get the Entities resource.
+        ///
+        /// @return Entities& Reference to the @ref Entities resource.
+        ///
+        /// @throw std::logic_error If the resource is not found.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-10-21)
+        ///
+        Entities &getEntities();
 
         ///
         /// @brief Get the Entity at the index @p index.

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -126,13 +126,16 @@ TEST(Registry, systems)
 TEST(Registry, resources)
 {
     ecstasy::Registry registry;
+    const ecstasy::Registry &cregistry = registry;
 
     /// Resource not present
     EXPECT_THROW(registry.getResource<Counter>(), std::logic_error);
+    EXPECT_THROW(cregistry.getResource<Counter>(), std::logic_error);
 
     /// Add resource with an initial value of 5 and add one
     registry.addResource<Counter>(5).count();
     EXPECT_EQ(registry.getResource<Counter>().value, 6);
+    EXPECT_EQ(cregistry.getResource<Counter>().value, 6);
 
     /// Try to add resource already present
     EXPECT_THROW(registry.addResource<Counter>(), std::logic_error);
@@ -141,12 +144,15 @@ TEST(Registry, resources)
 TEST(Registry, storages)
 {
     ecstasy::Registry registry;
+    const ecstasy::Registry &cregistry = registry;
 
-    /// Resource not present
-    EXPECT_THROW(registry.getStorage<Counter>(), std::logic_error);
+    /// Storage not present
     EXPECT_THROW(registry.getStorage<A>(), std::logic_error);
+    EXPECT_THROW(cregistry.getStorage<A>(), std::logic_error);
+    /// First call instantiate the storage and the second only fetch it.
     EXPECT_EQ(registry.getStorageSafe<A>().size(), 0);
     EXPECT_EQ(registry.getStorageSafe<A>().size(), 0);
+    EXPECT_EQ(cregistry.getStorage<A>().size(), 0);
 
     /// Add resource with an initial value of 5 and add one
     registry.addStorage<Counter>();
@@ -156,21 +162,22 @@ TEST(Registry, storages)
 TEST(Registry, erase_entities)
 {
     ecstasy::Registry registry;
+    const ecstasy::Registry &cregistry = registry;
 
     for (int i = 0; i < 10; i++)
         registry.entityBuilder().with<Position>(1, 2).with<Size>(3, 4).build();
-    GTEST_ASSERT_EQ(registry.getResource<ecstasy::Entities>().getMask(), util::BitSet("1111111111"));
+    GTEST_ASSERT_EQ(cregistry.getEntities().getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_EQ(registry.getStorage<Position>().getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_EQ(registry.getStorage<Size>().getMask(), util::BitSet("1111111111"));
     registry.eraseEntity(1);
     registry.eraseEntity(5);
-    GTEST_ASSERT_EQ(registry.getResource<ecstasy::Entities>().getMask(), util::BitSet("1111011101"));
+    GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("1111011101"));
     GTEST_ASSERT_EQ(registry.getStorage<Position>().getMask(), util::BitSet("1111011101"));
     GTEST_ASSERT_EQ(registry.getStorage<Size>().getMask(), util::BitSet("1111011101"));
 
-    GTEST_ASSERT_TRUE(registry.getResource<ecstasy::Entities>().isAlive(registry.getEntity(0)));
-    GTEST_ASSERT_FALSE(registry.getResource<ecstasy::Entities>().isAlive(registry.getEntity(1)));
-    GTEST_ASSERT_FALSE(registry.getResource<ecstasy::Entities>().isAlive(registry.getEntity(5)));
+    GTEST_ASSERT_TRUE(cregistry.getEntities().isAlive(registry.getEntity(0)));
+    GTEST_ASSERT_FALSE(registry.getEntities().isAlive(registry.getEntity(1)));
+    GTEST_ASSERT_FALSE(registry.getEntities().isAlive(registry.getEntity(5)));
 }
 
 TEST(Registry, EntityBuilder)


### PR DESCRIPTION
# Description

Introduce `getEntities` Registry method in const and non const form.
It is only syntactic sugar for `registry.getResource<Entities>()`.

Implemented const forms of `getStorage` and `getResource` methods.

Close #12

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The following registry unit tests have been updated:
- resources
- storages
- erase_entities

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
