### PR TITLE
Changed Maybe modifier QueryData type to use std::optional

### DIFF
--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -250,8 +250,8 @@ TEST(Query, Maybe)
         auto [pos, velocity, vec] = *it;
         GTEST_ASSERT_EQ(Vector2i(index * 2, index * 10), pos);
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(vec, nullptr);
-        GTEST_ASSERT_EQ(*vec, Vector2i(index * 4, index * 6));
+        GTEST_ASSERT_TRUE(vec);
+        GTEST_ASSERT_EQ(vec->get(), Vector2i(index * 4, index * 6));
     }
 
     /// 6
@@ -261,7 +261,7 @@ TEST(Query, Maybe)
         auto [pos, velocity, vec] = *it;
         GTEST_ASSERT_EQ(Vector2i(index * 2, index * 10), pos);
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_EQ(vec, nullptr);
+        GTEST_ASSERT_FALSE(vec);
     }
     /// 8
     ++it;
@@ -270,8 +270,8 @@ TEST(Query, Maybe)
         auto [pos, velocity, vec] = *it;
         GTEST_ASSERT_EQ(Vector2i(index * 2, index * 10), pos);
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(vec, nullptr);
-        GTEST_ASSERT_EQ(*vec, Vector2i(index * 4, index * 6));
+        GTEST_ASSERT_TRUE(vec);
+        GTEST_ASSERT_EQ(vec->get(), Vector2i(index * 4, index * 6));
     }
     /// 12
     ++it;
@@ -280,8 +280,8 @@ TEST(Query, Maybe)
         auto [pos, velocity, vec] = *it;
         GTEST_ASSERT_EQ(Vector2i(index * 2, index * 10), pos);
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(vec, nullptr);
-        GTEST_ASSERT_EQ(*vec, Vector2i(index * 4, index * 6));
+        GTEST_ASSERT_TRUE(vec);
+        GTEST_ASSERT_EQ(vec->get(), Vector2i(index * 4, index * 6));
     }
 
     /// 18
@@ -291,7 +291,7 @@ TEST(Query, Maybe)
         auto [pos, velocity, vec] = *it;
         GTEST_ASSERT_EQ(Vector2i(index * 2, index * 10), pos);
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_EQ(vec, nullptr);
+        GTEST_ASSERT_FALSE(vec);
     }
 
     /// 24
@@ -301,7 +301,7 @@ TEST(Query, Maybe)
         auto [pos, velocity, vec] = *it;
         GTEST_ASSERT_EQ(Vector2i(index * 2, index * 10), pos);
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(vec, nullptr);
-        GTEST_ASSERT_EQ(*vec, Vector2i(index * 4, index * 6));
+        GTEST_ASSERT_TRUE(vec);
+        GTEST_ASSERT_EQ(vec->get(), Vector2i(index * 4, index * 6));
     }
 }

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -315,8 +315,8 @@ TEST(Registry, MaybeQuery)
         auto [pos, velocity, density] = *it;
         GTEST_ASSERT_EQ(pos.v, Vector2i(index * 2, index * 10));
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(density, nullptr);
-        GTEST_ASSERT_EQ(*density, index * 4);
+        GTEST_ASSERT_TRUE(density);
+        GTEST_ASSERT_EQ(density->get(), index * 4);
     }
 
     /// 6
@@ -326,7 +326,7 @@ TEST(Registry, MaybeQuery)
         auto [pos, velocity, density] = *it;
         GTEST_ASSERT_EQ(pos.v, Vector2i(index * 2, index * 10));
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_EQ(density, nullptr);
+        GTEST_ASSERT_FALSE(density);
     }
     /// 8
     ++it;
@@ -335,8 +335,8 @@ TEST(Registry, MaybeQuery)
         auto [pos, velocity, density] = *it;
         GTEST_ASSERT_EQ(pos.v, Vector2i(index * 2, index * 10));
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(density, nullptr);
-        GTEST_ASSERT_EQ(*density, index * 4);
+        GTEST_ASSERT_TRUE(density);
+        GTEST_ASSERT_EQ(density->get(), index * 4);
     }
     /// 12
     ++it;
@@ -345,8 +345,8 @@ TEST(Registry, MaybeQuery)
         auto [pos, velocity, density] = *it;
         GTEST_ASSERT_EQ(pos.v, Vector2i(index * 2, index * 10));
         GTEST_ASSERT_EQ(velocity.v, Vector2i(index * 10, index * 2));
-        GTEST_ASSERT_NE(density, nullptr);
-        GTEST_ASSERT_EQ(*density, index * 4);
+        GTEST_ASSERT_TRUE(density);
+        GTEST_ASSERT_EQ(density->get(), index * 4);
     }
 }
 
@@ -461,4 +461,7 @@ TEST(Registry, ImplicitWhere)
         auto implicitQuery = registry.select<Position, ecstasy::Maybe<Density>>().where<Velocity>(allocator);
         GTEST_ASSERT_EQ(explicitQuery.getMask(), implicitQuery.getMask());
     }
+
+    /// registry.select<Position, Maybe<Velocity>>().where<Position, Or<Density, Velocity>>()
+    /// Select<Position, Maybe<Velocity>>::where(positions, DensityOrVelocity)
 }


### PR DESCRIPTION
# Description

Now the Maybe modifier QueryData are std::optional which is more adapted than a raw pointer.

Close #37

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing tests have been updated.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
