### PR TITLE
Use a std::optional for registry query modifier allocator

### DIFF
--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -370,6 +370,11 @@ TEST(Registry, MaybeSelect)
     auto select =
         registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>(
             allocator);
+    /// Need to create a lambda because the EXPECT_THROW macro interprets the template parameters as macro parameters
+    auto execMissingAllocator = [&registry]() {
+        registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>();
+    };
+    EXPECT_THROW(execMissingAllocator(), std::logic_error);
     GTEST_ASSERT_EQ(query.getMask(), select.getMask());
     GTEST_ASSERT_EQ(query.getMask(), util::BitSet("11000101000001"));
 }


### PR DESCRIPTION
# Description

All registry functions taking a ModifiersAllocator now takes a std::optional<ModifiersAllocator> instead. It allows to merge all the depending methods to simplify code maintainability. 

Also throw a std::logic_error when the allocator is required but missing.

Close #36

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing tests have been updated.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
