### PR TITLE
Add registry hasResource method

### DIFF
--- a/src/ecstasy/query/concepts/QueryableNeedAdjust.hpp
+++ b/src/ecstasy/query/concepts/QueryableNeedAdjust.hpp
@@ -28,7 +28,7 @@ namespace ecstasy::query
     concept QueryableNeedAdjust = requires(Q &queryable, std::size_t maxSize)
     {
         /// Ensure the type is a queryable
-        Queryable<Q>;
+        requires Queryable<Q>;
 
         // clang-format off
         { queryable.adjustMask(maxSize) } -> std::same_as<void>;

--- a/src/ecstasy/registry/Registry.hpp
+++ b/src/ecstasy/registry/Registry.hpp
@@ -351,6 +351,22 @@ namespace ecstasy
         }
 
         ///
+        /// @brief Check whether the registry has the resource of type @b R.
+        ///
+        /// @tparam R Type of the resource.
+        ///
+        /// @return bool Whether the registry contains a resource instance of type @b R.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-06)
+        ///
+        template <std::derived_from<Resource> R>
+        bool hasResource() const
+        {
+            return _resources.contains<R>();
+        }
+
+        ///
         /// @brief Get the Resource of type @b R.
         ///
         /// @tparam R Type of the resource to fetch.

--- a/src/ecstasy/registry/concepts/RegistryModifier.hpp
+++ b/src/ecstasy/registry/concepts/RegistryModifier.hpp
@@ -30,7 +30,7 @@ namespace ecstasy
     concept RegistryModifier = requires()
     {
         typename M::Modifier;
-        query::Queryable<typename M::Modifier>;
+        requires query::Queryable<typename M::Modifier>;
     };
 
 } // namespace ecstasy

--- a/src/ecstasy/resource/entity/RegistryEntity.hpp
+++ b/src/ecstasy/resource/entity/RegistryEntity.hpp
@@ -118,6 +118,19 @@ namespace ecstasy
             return _registry.getStorageSafe<C>().contains(_index);
         }
 
+        ///
+        /// @brief Get the entity owning registry.
+        ///
+        /// @return constexpr Registry& Reference to the entity owning registry.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-06)
+        ///
+        constexpr Registry &getRegistry()
+        {
+            return _registry;
+        }
+
       private:
         Registry &_registry;
     };

--- a/tests/entity/tests_RegistryEntity.cpp
+++ b/tests/entity/tests_RegistryEntity.cpp
@@ -24,6 +24,8 @@ TEST(RegistryEntity, add_has)
     GTEST_ASSERT_FALSE(e1.has<Position>());
     e1.add<Position>(5, 3);
     GTEST_ASSERT_TRUE(e1.has<Position>());
+
+    GTEST_ASSERT_EQ(&registry, &e1.getRegistry());
 }
 
 TEST(RegistryEntity, get)

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -68,8 +68,7 @@ struct Counter : public ecstasy::Resource {
 
 namespace test
 {
-    struct Comp {
-    };
+    struct Comp {};
 } // namespace test
 
 SET_COMPONENT_STORAGE(test::Comp, ecstasy::MapStorage)
@@ -115,10 +114,8 @@ struct Size {
 using Density = int;
 
 /// Movable marker to test complex queries
-struct Movable {
-};
-struct Static {
-};
+struct Movable {};
+struct Static {};
 
 struct Gravity : public ecstasy::ISystem {
     void run(ecstasy::Registry &registry) override final
@@ -166,11 +163,13 @@ TEST(Registry, resources)
     const ecstasy::Registry &cregistry = registry;
 
     /// Resource not present
+    ASSERT_FALSE(registry.hasResource<Counter>());
     EXPECT_THROW(registry.getResource<Counter>(), std::logic_error);
     EXPECT_THROW(cregistry.getResource<Counter>(), std::logic_error);
 
     /// Add resource with an initial value of 5 and add one
     registry.addResource<Counter>(5).count();
+    ASSERT_TRUE(registry.hasResource<Counter>());
     EXPECT_EQ(registry.getResource<Counter>().value, 6);
     EXPECT_EQ(cregistry.getResource<Counter>().value, 6);
 


### PR DESCRIPTION
# Description

Add registry hasResource method, which checks whether a resource is contained in the registry or not.
Also add RegistryEntity getRegistry method.

Close: #52

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Minor fixes

Add missing requires specifier in existing concepts.

# How Has This Been Tested?

New asserts have been added in existing tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
