### PR TITLE
Feature/66 entity multiple listeners

### DIFF
--- a/src/ecstasy/integrations/event/listeners/CMakeLists.txt
+++ b/src/ecstasy/integrations/event/listeners/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SRCROOT ${SRCROOT}/listeners)
 
 set(SRC 
     ${SRC}
+    ${INCROOT}/EventListeners.hpp
     ${INCROOT}/KeyListener.hpp
     ${INCROOT}/MouseButtonListener.hpp
     ${INCROOT}/MouseMoveListener.hpp

--- a/src/ecstasy/integrations/event/listeners/EventListeners.hpp
+++ b/src/ecstasy/integrations/event/listeners/EventListeners.hpp
@@ -24,40 +24,119 @@ namespace ecstasy
 
 namespace ecstasy::integration::event
 {
+    ///
+    /// @brief Event listener component type.
+    ///
+    /// @tparam E Event type to listen to.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-11-18)
+    ///
     template <typename E>
     using EventListener = std::function<void(Registry &, Entity, const E &)>;
 
+    ///
+    /// @brief Event listeners component type. Allows to have several listeners for the same event in a single entity.
+    ///
+    /// @note This is just a vector of @ref EventListener<E>.
+    ///
+    /// @tparam E Event type.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-11-18)
+    ///
     template <typename E>
     class EventListeners {
       public:
+        ///
+        /// @brief Construct a new empty EventListeners.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         constexpr EventListeners() = default;
+
+        ///
+        /// @brief Construct a new EventListeners with the given listeners.
+        ///
+        /// @param[in] listeners Initial listeners.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         constexpr EventListeners(std::vector<EventListener<E>> &&listeners) : _listeners(listeners)
         {
         }
 
+        ///
+        /// @brief Destroy the Event Listeners.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         ~EventListeners() = default;
 
+        ///
+        /// @brief Add a listener.
+        ///
+        /// @param[in] listener new listener.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         void add(EventListener<E> listener)
         {
             _listeners.push_back(listener);
         }
 
+        ///
+        /// @brief Delete all the listeners.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         constexpr void clear()
         {
             _listeners.clear();
         }
 
+        ///
+        /// @brief Call the internal listeners.
+        ///
+        /// @param[in] registry Registry to forward to the listeners.
+        /// @param[in] entity Entity owning this component.
+        /// @param[in] event Source event.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         constexpr void operator()(Registry &registry, Entity entity, const E &event)
         {
             for (EventListener<E> &e : _listeners)
                 e(registry, entity, event);
         }
 
+        ///
+        /// @brief Get the Inner listeners container.
+        ///
+        /// @return constexpr std::vector<EventListener<E>>& A reference to the inner container.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         constexpr std::vector<EventListener<E>> &getInner()
         {
             return _listeners;
         }
 
+        ///
+        /// @brief Get the Inner listeners container.
+        ///
+        /// @return constexpr const std::vector<EventListener<E>>& A const reference to the inner container.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-18)
+        ///
         constexpr const std::vector<EventListener<E>> &getInner() const
         {
             return _listeners;

--- a/src/ecstasy/integrations/event/listeners/EventListeners.hpp
+++ b/src/ecstasy/integrations/event/listeners/EventListeners.hpp
@@ -1,0 +1,71 @@
+///
+/// @file EventListeners.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-11-17
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_INTEGRATIONS_EVENT_LISTENERS_EVENTLISTENERS_HPP_
+#define ECSTASY_INTEGRATIONS_EVENT_LISTENERS_EVENTLISTENERS_HPP_
+
+#include <functional>
+#include <vector>
+
+#include "ecstasy/resources/entity/Entity.hpp"
+
+namespace ecstasy
+{
+    class Registry;
+}
+
+namespace ecstasy::integration::event
+{
+    template <typename E>
+    using EventListener = std::function<void(Registry &, Entity, const E &)>;
+
+    template <typename E>
+    class EventListeners {
+      public:
+        constexpr EventListeners() = default;
+        constexpr EventListeners(std::vector<EventListener<E>> &&listeners) : _listeners(listeners)
+        {
+        }
+
+        ~EventListeners() = default;
+
+        void add(EventListener<E> listener)
+        {
+            _listeners.push_back(listener);
+        }
+
+        constexpr void clear()
+        {
+            _listeners.clear();
+        }
+
+        constexpr void operator()(Registry &registry, Entity entity, const E &event)
+        {
+            for (EventListener<E> &e : _listeners)
+                e(registry, entity, event);
+        }
+
+        constexpr std::vector<EventListener<E>> &getInner()
+        {
+            return _listeners;
+        }
+
+        constexpr const std::vector<EventListener<E>> &getInner() const
+        {
+            return _listeners;
+        }
+
+      private:
+        std::vector<EventListener<E>> _listeners;
+    };
+} // namespace ecstasy::integration::event
+
+#endif /* !ECSTASY_INTEGRATIONS_EVENT_LISTENERS_EVENTLISTENERS_HPP_ */

--- a/src/ecstasy/integrations/event/listeners/KeyListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/KeyListener.hpp
@@ -12,19 +12,13 @@
 #ifndef ECSTASY_INTEGRATIONS_EVENT_EVENTS_KEYLISTENER_HPP_
 #define ECSTASY_INTEGRATIONS_EVENT_EVENTS_KEYLISTENER_HPP_
 
-#include <functional>
-#include "ecstasy/resources/entity/Entity.hpp"
-
-namespace ecstasy
-{
-    class Registry;
-} // namespace ecstasy
+#include "EventListeners.hpp"
 
 namespace ecstasy::integration::event
 {
     struct KeyEvent;
 
-    using KeyListener = std::function<void(Registry &, Entity, const KeyEvent &)>;
+    using KeyListener = EventListener<KeyEvent>;
 } // namespace ecstasy::integration::event
 
 #endif /* !ECSTASY_INTEGRATIONS_EVENT_EVENTS_KEYLISTENER_HPP_ */

--- a/src/ecstasy/integrations/event/listeners/KeyListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/KeyListener.hpp
@@ -18,6 +18,7 @@ namespace ecstasy::integration::event
 {
     struct KeyEvent;
 
+    /// @brief @ref KeyEvent listener.
     using KeyListener = EventListener<KeyEvent>;
 } // namespace ecstasy::integration::event
 

--- a/src/ecstasy/integrations/event/listeners/MouseButtonListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/MouseButtonListener.hpp
@@ -12,19 +12,13 @@
 #ifndef ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEBUTTONLISTENER_HPP_
 #define ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEBUTTONLISTENER_HPP_
 
-#include <functional>
-#include "ecstasy/resources/entity/Entity.hpp"
-
-namespace ecstasy
-{
-    class Registry;
-} // namespace ecstasy
+#include "EventListeners.hpp"
 
 namespace ecstasy::integration::event
 {
     struct MouseButtonEvent;
 
-    using MouseButtonListener = std::function<void(Registry &, Entity, const MouseButtonEvent &)>;
+    using MouseButtonListener = EventListener<MouseButtonEvent>;
 } // namespace ecstasy::integration::event
 
 #endif /* !ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEBUTTONLISTENER_HPP_ */

--- a/src/ecstasy/integrations/event/listeners/MouseButtonListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/MouseButtonListener.hpp
@@ -18,6 +18,7 @@ namespace ecstasy::integration::event
 {
     struct MouseButtonEvent;
 
+    /// @brief @ref MouseButtonEvent listener.
     using MouseButtonListener = EventListener<MouseButtonEvent>;
 } // namespace ecstasy::integration::event
 

--- a/src/ecstasy/integrations/event/listeners/MouseMoveListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/MouseMoveListener.hpp
@@ -18,6 +18,7 @@ namespace ecstasy::integration::event
 {
     struct MouseMoveEvent;
 
+    /// @brief @ref MouseMoveEvent listener.
     using MouseMoveListener = EventListener<MouseMoveEvent>;
 } // namespace ecstasy::integration::event
 

--- a/src/ecstasy/integrations/event/listeners/MouseMoveListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/MouseMoveListener.hpp
@@ -12,19 +12,13 @@
 #ifndef ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEMOVELISTENER_HPP_
 #define ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEMOVELISTENER_HPP_
 
-#include <functional>
-#include "ecstasy/resources/entity/Entity.hpp"
-
-namespace ecstasy
-{
-    class Registry;
-} // namespace ecstasy
+#include "EventListeners.hpp"
 
 namespace ecstasy::integration::event
 {
     struct MouseMoveEvent;
 
-    using MouseMoveListener = std::function<void(Registry &, Entity, const MouseMoveEvent &)>;
+    using MouseMoveListener = EventListener<MouseMoveEvent>;
 } // namespace ecstasy::integration::event
 
 #endif /* !ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEMOVELISTENER_HPP_ */

--- a/src/ecstasy/integrations/event/listeners/MouseWheelScrollListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/MouseWheelScrollListener.hpp
@@ -18,6 +18,7 @@ namespace ecstasy::integration::event
 {
     struct MouseWheelScrollEvent;
 
+    /// @brief @ref MouseWheelScrollEvent listener.
     using MouseWheelScrollListener = EventListener<MouseWheelScrollEvent>;
 } // namespace ecstasy::integration::event
 

--- a/src/ecstasy/integrations/event/listeners/MouseWheelScrollListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/MouseWheelScrollListener.hpp
@@ -12,19 +12,13 @@
 #ifndef ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEWHEELSCROLLLISTENER_HPP_
 #define ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEWHEELSCROLLLISTENER_HPP_
 
-#include <functional>
-#include "ecstasy/resources/entity/Entity.hpp"
-
-namespace ecstasy
-{
-    class Registry;
-} // namespace ecstasy
+#include "EventListeners.hpp"
 
 namespace ecstasy::integration::event
 {
     struct MouseWheelScrollEvent;
 
-    using MouseWheelScrollListener = std::function<void(Registry &, Entity, const MouseWheelScrollEvent &)>;
+    using MouseWheelScrollListener = EventListener<MouseWheelScrollEvent>;
 } // namespace ecstasy::integration::event
 
 #endif /* !ECSTASY_INTEGRATION_EVENTS_LISTENERS_MOUSEWHEELSCROLLLISTENER_HPP_ */

--- a/src/ecstasy/integrations/event/listeners/TextEnteredListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/TextEnteredListener.hpp
@@ -18,6 +18,7 @@ namespace ecstasy::integration::event
 {
     struct TextEnteredEvent;
 
+    /// @brief @ref TextEnteredEvent listener.
     using TextEnteredListener = EventListener<TextEnteredEvent>;
 } // namespace ecstasy::integration::event
 

--- a/src/ecstasy/integrations/event/listeners/TextEnteredListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/TextEnteredListener.hpp
@@ -12,19 +12,13 @@
 #ifndef ECSTASY_INTEGRATIONS_EVENTS_LISTENERS_TEXTENTEREDLISTENER_HPP_
 #define ECSTASY_INTEGRATIONS_EVENTS_LISTENERS_TEXTENTEREDLISTENER_HPP_
 
-#include <functional>
-#include "ecstasy/resources/entity/Entity.hpp"
-
-namespace ecstasy
-{
-    class Registry;
-} // namespace ecstasy
+#include "EventListeners.hpp"
 
 namespace ecstasy::integration::event
 {
     struct TextEnteredEvent;
 
-    using TextEnteredListener = std::function<void(Registry &, Entity, const TextEnteredEvent &)>;
+    using TextEnteredListener = EventListener<TextEnteredEvent>;
 } // namespace ecstasy::integration::event
 
 #endif /* !ECSTASY_INTEGRATIONS_EVENTS_LISTENERS_TEXTENTEREDLISTENER_HPP_ */

--- a/tests/integration/event/tests_Keyboard.cpp
+++ b/tests/integration/event/tests_Keyboard.cpp
@@ -19,6 +19,7 @@ TEST(Event, KeyPressed)
     event::Keyboard &keyboardState = registry.addResource<event::Keyboard>();
     int val1 = 0;
     int val2 = 0;
+    int multiEvents = 0;
 
     GTEST_ASSERT_TRUE(keyboardState.isKeyUp(event::Keyboard::Key::A));
     event::EventsManager::handleEvent(registry, event::KeyPressedEvent(event::Keyboard::Key::A));
@@ -32,6 +33,21 @@ TEST(Event, KeyPressed)
             if (event.pressed)
                 val1++;
         })
+        .with<event::EventListeners<event::KeyEvent>>(std::initializer_list<event::EventListener<event::KeyEvent>>{
+            [&multiEvents](Registry &r, Entity e, const event::KeyEvent &event) {
+                (void)r;
+                (void)e;
+                (void)event;
+                if (event.pressed)
+                    multiEvents++;
+            },
+            [&multiEvents](Registry &r, Entity e, const event::KeyEvent &event) {
+                (void)r;
+                (void)e;
+                (void)event;
+                if (event.pressed)
+                    multiEvents += 3;
+            }})
         .build();
     registry.entityBuilder()
         .with<event::KeyListener>([&val2](Registry &r, Entity e, const event::KeyEvent &event) {
@@ -46,6 +62,7 @@ TEST(Event, KeyPressed)
     event::EventsManager::handleEvent(registry, event::KeyPressedEvent(event::Keyboard::Key::B));
     GTEST_ASSERT_EQ(val1, 1);
     GTEST_ASSERT_EQ(val2, -1);
+    GTEST_ASSERT_EQ(multiEvents, 4); /// 1 + 3
 }
 
 TEST(Event, KeyReleased)


### PR DESCRIPTION
# Description

### EventListener

New templated type for all the events, now the events are all of the form EventListener<E>
```cpp
using EventListener = std::function<void(Registry &, Entity, const E &)>;

using KeyListener = EventListener<KeyEvent>;
/// same for all events
```

### EventListeners

New templated component allowing to hold several listeners for the same event on a single entity:

_(brace intializer lists can't deduce the type so we must specify it explicitely using the std::initializer_list type)_
```cpp
registry.entityBuilder().with<EventListeners<KeyEvent>>(
    std::initializer_list<EventListener<KeyEvent>>{
        [](/*listener parameters*/) {
            /*listener definition*/
        },
         /// another listener...
    }
);
```

Close #66 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

A new test have been added to the existing ones.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
