### PR TITLE
Introduce dependent options in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.19.0)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros)
 
 include(Options)
-include(DetectCompiler)
 include(macros)
 
 # Resolve dependencies before applying C++20 standards to avoid incompatibility
@@ -20,6 +19,8 @@ set(VERSION_PATCH 0)
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+include(DetectCompiler)
 
 set(ECSTASY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/lib/")
 file(MAKE_DIRECTORY ${ECSTASY_OUTPUT_DIRECTORY})

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.17)
+
+include(CMakeDependentOption)
 
 option(BUILD_TEST_SUITE "Whether the test suite must be built." OFF)
 option(ENABLE_CODE_COVERAGE "Whether the code coverage must be enabled" OFF)
@@ -6,5 +8,23 @@ option(BUILD_SHARED_LIBS "Whether ecstasy must be built as a shared library or n
 
 ## Integration libraries
 option(ECSTASY_INTEGRATIONS_EVENT "Events managing integration. Include event listeners and input states (mouse, keyboard, gamepad)." OFF)
-option(ECSTASY_INTEGRATIONS_SFML "SFML library integration." OFF)
-option(ECSTASY_INTEGRATIONS_SFML_BUILD_DEMO "Build SFML integration demo projects." OFF)
+CMAKE_DEPENDENT_OPTION(ECSTASY_INTEGRATIONS_SFML "SFML library integration." OFF ECSTASY_INTEGRATIONS_EVENT OFF)
+CMAKE_DEPENDENT_OPTION(ECSTASY_INTEGRATIONS_SFML_BUILD_DEMO "Build SFML integration demo projects." OFF ECSTASY_INTEGRATIONS_SFML OFF)
+
+
+## Display configuration
+message(STATUS "ECSTASY Options:")
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+    message(STATUS "Build Tests: ${BUILD_TEST_SUITE}")
+    message(STATUS "Enable code Coverage: ${ENABLE_CODE_COVERAGE}")
+    message(STATUS "Build shared libraries: ${BUILD_SHARED_LIBS}")
+    ## Integrations
+    message(STATUS "Build integrations")
+    list(APPEND CMAKE_MESSAGE_INDENT "  ")
+        message(STATUS "Event: ${ECSTASY_INTEGRATIONS_EVENT}")
+        message(STATUS "SFML: ${ECSTASY_INTEGRATIONS_SFML}")
+        list(APPEND CMAKE_MESSAGE_INDENT "  ")
+            message(STATUS "Build demos: ${ECSTASY_INTEGRATIONS_SFML_BUILD_DEMO}")
+        list(POP_BACK CMAKE_MESSAGE_INDENT)
+    list(POP_BACK CMAKE_MESSAGE_INDENT)
+list(POP_BACK CMAKE_MESSAGE_INDENT)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17)
 include(CMakeDependentOption)
 
 option(BUILD_TEST_SUITE "Whether the test suite must be built." OFF)
-option(ENABLE_CODE_COVERAGE "Whether the code coverage must be enabled" OFF)
+option(ENABLE_TEST_COVERAGE "Whether the tests code coverage must be enabled" OFF)
 option(BUILD_SHARED_LIBS "Whether ecstasy must be built as a shared library or not" OFF)
 
 ## Integration libraries
@@ -16,7 +16,7 @@ CMAKE_DEPENDENT_OPTION(ECSTASY_INTEGRATIONS_SFML_BUILD_DEMO "Build SFML integrat
 message(STATUS "ECSTASY Options:")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
     message(STATUS "Build Tests: ${BUILD_TEST_SUITE}")
-    message(STATUS "Enable code Coverage: ${ENABLE_CODE_COVERAGE}")
+    message(STATUS "Enable test coverage: ${ENABLE_TEST_COVERAGE}")
     message(STATUS "Build shared libraries: ${BUILD_SHARED_LIBS}")
     ## Integrations
     message(STATUS "Build integrations")


### PR DESCRIPTION
# Description

Options requiring other options are now declared using cmake_dependent_options and all options are listed on cmake configuration.

Close #65

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
