### PR TITLE
Feature/76 additional or operands

### DIFF
--- a/src/ecstasy/integrations/event/EventsManager.cpp
+++ b/src/ecstasy/integrations/event/EventsManager.cpp
@@ -47,8 +47,9 @@ namespace ecstasy::integration::event
             registry
                 .select<Entities, Maybe<EventListener<KeyEvent>>, Maybe<EventListeners<KeyEvent>>,
                     Maybe<KeySequenceListener>, Maybe<KeyCombinationListener>>()
-                .where<Or<EventListener<KeyEvent>,
-                    Or<EventListeners<KeyEvent>, Or<KeySequenceListener, KeyCombinationListener>>>>(allocator)) {
+                .where<
+                    Or<EventListener<KeyEvent>, EventListeners<KeyEvent>, KeySequenceListener, KeyCombinationListener>>(
+                    allocator)) {
             if (listener)
                 listener.value()(registry, entity, event);
             if (listeners)

--- a/src/ecstasy/query/concepts/Modifier.hpp
+++ b/src/ecstasy/query/concepts/Modifier.hpp
@@ -13,15 +13,28 @@
 #define ECSTASY_QUERY_CONCEPTS_MODIFIER_HPP_
 
 #include "Queryable.hpp"
+#include "ecstasy/query/modifiers/Modifier.hpp"
 
 namespace ecstasy::query
 {
+    ///
+    /// @brief Defines a query modifier type.
+    ///
+    /// @tparam M Evaluated type.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-11-22)
+    ///
     template <typename M>
     concept Modifier = requires(M &modifier)
     {
         /// Data stored in the queryable.
         requires Queryable<M>;
 
+        /// Modifiers must inherit from the @ref ecstasy::query::modifier::Modifier .
+        requires std::derived_from<M, ecstasy::query::modifier::Modifier>;
+
+        /// Modifier operands
         typename M::Operands;
     };
 } // namespace ecstasy::query

--- a/src/ecstasy/query/concepts/Modifier.hpp
+++ b/src/ecstasy/query/concepts/Modifier.hpp
@@ -1,0 +1,29 @@
+///
+/// @file Modifier.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-11-22
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONCEPTS_MODIFIER_HPP_
+#define ECSTASY_QUERY_CONCEPTS_MODIFIER_HPP_
+
+#include "Queryable.hpp"
+
+namespace ecstasy::query
+{
+    template <typename M>
+    concept Modifier = requires(M &modifier)
+    {
+        /// Data stored in the queryable.
+        requires Queryable<M>;
+
+        typename M::Operands;
+    };
+} // namespace ecstasy::query
+
+#endif /* !ECSTASY_QUERY_CONCEPTS_MODIFIER_HPP_ */

--- a/src/ecstasy/query/concepts/include.hpp
+++ b/src/ecstasy/query/concepts/include.hpp
@@ -12,6 +12,7 @@
 #ifndef ECSTASY_QUERY_CONCEPTS_HPP_
 #define ECSTASY_QUERY_CONCEPTS_HPP_
 
+#include "Modifier.hpp"
 #include "Queryable.hpp"
 #include "QueryableNeedAdjust.hpp"
 

--- a/src/ecstasy/query/modifiers/And.hpp
+++ b/src/ecstasy/query/modifiers/And.hpp
@@ -30,7 +30,7 @@ namespace ecstasy::query::modifier
     /// @since 1.0.0 (2022-10-27)
     ///
     template <Queryable Q1, Queryable Q2, Queryable... Qs>
-    class And : public BinaryModifier {
+    class And : public Modifier {
       public:
         /// @brief @ref Modifier constraint.
         using Operands = std::tuple<Q1, Q2, Qs...>;

--- a/src/ecstasy/query/modifiers/And.hpp
+++ b/src/ecstasy/query/modifiers/And.hpp
@@ -91,11 +91,7 @@ namespace ecstasy::query::modifier
         ///
         auto getOperandData(size_t operandId, size_t index)
         {
-            auto &operand = std::get<operandId>(_operands);
-
-            if (index < operand.getMask().size() && operand.getMask()[index])
-                return operand.getQueryData(index);
-            return std::nullopt;
+            return std::get<operandId>(_operands).getQueryData(index);
         }
 
         ///

--- a/src/ecstasy/query/modifiers/Maybe.hpp
+++ b/src/ecstasy/query/modifiers/Maybe.hpp
@@ -33,10 +33,13 @@ namespace ecstasy::query::modifier
     /// @since 1.0.0 (2022-10-24)
     ///
     template <Queryable Q>
-    class Maybe : public UnaryModifier {
+    class Maybe : public Modifier {
       public:
         /// @brief Wrapped queryable.
         using Internal = Q;
+
+        /// @brief @ref Modifier constraint.
+        using Operands = std::tuple<Q>;
 
         /// @brief @ref Queryable constaint.
         using QueryData = util::meta::add_optional_t<typename Internal::QueryData>;

--- a/src/ecstasy/query/modifiers/Not.hpp
+++ b/src/ecstasy/query/modifiers/Not.hpp
@@ -31,10 +31,13 @@ namespace ecstasy::query::modifier
     /// @since 1.0.0 (2022-10-24)
     ///
     template <Queryable Q>
-    class Not : public UnaryModifier {
+    class Not : public Modifier {
       public:
         /// @brief Wrapped queryable.
         using Internal = Q;
+
+        /// @brief @ref Modifier constraint.
+        using Operands = std::tuple<Q>;
 
         /// @brief @ref Queryable constaint.
         using QueryData = typename Internal::QueryData;

--- a/src/ecstasy/query/modifiers/Or.hpp
+++ b/src/ecstasy/query/modifiers/Or.hpp
@@ -194,7 +194,7 @@ namespace ecstasy::query::modifier
             (void)int_seq;
             _mask = std::get<0>(_operands).getMask();
             combineMask(std::get<1>(_operands).getMask());
-            std::make_tuple((combineMask(std::get<ints + 2>(_operands).getMask()), 0)...);
+            std::ignore = std::make_tuple((combineMask(std::get<ints + 2>(_operands).getMask()), 0)...);
         }
 
         std::tuple<Q1 &, Q2 &, Qs &...> _operands;

--- a/src/ecstasy/query/modifiers/Or.hpp
+++ b/src/ecstasy/query/modifiers/Or.hpp
@@ -31,7 +31,7 @@ namespace ecstasy::query::modifier
     /// @since 1.0.0 (2022-10-27)
     ///
     template <Queryable Q1, Queryable Q2, Queryable... Qs>
-    class Or : public BinaryModifier {
+    class Or : public Modifier {
       public:
         /// @brief @ref Modifier constraint.
         using Operands = std::tuple<Q1, Q2, Qs...>;

--- a/src/ecstasy/query/modifiers/Or.hpp
+++ b/src/ecstasy/query/modifiers/Or.hpp
@@ -23,30 +23,30 @@ namespace ecstasy::query::modifier
     ///
     /// @tparam Q1 Left operand queryable type.
     /// @tparam Q2 Right operand queryable type.
+    /// @tparam Qs Additional operand queryable types.
     ///
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-27)
     ///
-    template <Queryable Q1, Queryable Q2>
+    template <Queryable Q1, Queryable Q2, Queryable... Qs>
     class Or : public BinaryModifier {
       public:
         /// @brief Left operand type (queryable)
         using LeftOperand = Q1;
 
-        /// @brief Left operand data type
-        using LeftQueryData = util::meta::add_optional_t<typename LeftOperand::QueryData>;
-
         /// @brief Right operand type (queryable)
         using RightOperand = Q2;
 
-        /// @brief Right operand data type
-        using RightQueryData = util::meta::add_optional_t<typename RightOperand::QueryData>;
-
-        /// @brief Wrapped queryables.
-        using Operands = std::tuple<Q1, Q2>;
+        /// @brief Operand types (queryable)
+        using Operands = std::tuple<Q1 &, Q2 &, Qs &...>;
 
         /// @brief @ref Queryable constaint.
-        using QueryData = std::tuple<LeftQueryData, RightQueryData>;
+        // clang-format off
+        using QueryData = std::tuple<
+            util::meta::add_optional_t<typename Q1::QueryData>,
+            util::meta::add_optional_t<typename Q2::QueryData>,
+            util::meta::add_optional_t<typename Qs::QueryData>...>;
+        // clang-format on
 
         ///
         /// @brief Construct a new Or Queryable modifier.
@@ -57,8 +57,8 @@ namespace ecstasy::query::modifier
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-10-27)
         ///
-        Or(LeftOperand &leftOperand, RightOperand &rightOperand)
-            : _leftOperand(leftOperand), _rightOperand(rightOperand)
+        Or(Q1 &firstOperand, Q2 &secondOperand, Qs &...otherOperands)
+            : _operands({firstOperand, secondOperand, otherOperands...})
         {
             reloadMask();
         }
@@ -92,30 +92,12 @@ namespace ecstasy::query::modifier
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-10-27)
         ///
-        LeftQueryData getLeftQueryData(size_t index)
+        auto getOperandData(size_t operandId, size_t index)
         {
-            if (index < _leftOperand.getMask().size() && _leftOperand.getMask()[index])
-                return LeftQueryData{_leftOperand.getQueryData(index)};
-            return std::nullopt;
-        }
+            auto &operand = std::get<operandId>(_operands);
 
-        ///
-        /// @brief Get a std::optional filled with the data of the right operand at index @p index if existing.
-        ///
-        /// @warning May throw exceptions, look at the @b RightOperand type equivalent method documentation.
-        ///
-        /// @param[in] index Index of the entity.
-        ///
-        /// @return @ref RightQueryData A std::optional filled with the right operand data at index @p index if
-        /// existing.
-        ///
-        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
-        /// @since 1.0.0 (2022-10-27)
-        ///
-        RightQueryData getRightQueryData(size_t index)
-        {
-            if (index < _rightOperand.getMask().size() && _rightOperand.getMask()[index])
-                return RightQueryData{_rightOperand.getQueryData(index)};
+            if (index < operand.getMask().size() && operand.getMask()[index])
+                return operand.getQueryData(index);
             return std::nullopt;
         }
 
@@ -134,7 +116,7 @@ namespace ecstasy::query::modifier
         ///
         QueryData getQueryData(size_t index)
         {
-            return std::make_tuple(getLeftQueryData(index), getRightQueryData(index));
+            return getQueryData(index, std::make_index_sequence<(sizeof...(Qs))>());
         }
 
         ///
@@ -145,18 +127,80 @@ namespace ecstasy::query::modifier
         ///
         void reloadMask()
         {
-            if (_leftOperand.getMask().size() > _rightOperand.getMask().size()) {
-                _mask = _leftOperand.getMask();
-                _mask.inplaceOr(_rightOperand.getMask());
-            } else {
-                _mask = _rightOperand.getMask();
-                _mask.inplaceOr(_leftOperand.getMask());
+            if constexpr (sizeof...(Qs) > 0)
+                combineOperandMasks(std::make_index_sequence<(sizeof...(Qs))>());
+            else {
+                auto &leftOperand = std::get<0>(_operands);
+                auto &rightOperand = std::get<1>(_operands);
+
+                if (leftOperand.getMask().size() > rightOperand.getMask().size()) {
+                    _mask = leftOperand.getMask();
+                    _mask.inplaceOr(rightOperand.getMask());
+                } else {
+                    _mask = rightOperand.getMask();
+                    _mask.inplaceOr(leftOperand.getMask());
+                }
             }
         }
 
       private:
-        LeftOperand &_leftOperand;
-        RightOperand &_rightOperand;
+        ///
+        /// @brief Get the the query data.
+        ///
+        /// @tparam ints Sequence values.
+        ///
+        /// @param[in] index Id of the query data to fetch.
+        /// @param[in] int_seq Sequence containing the queryables ids.
+        ///
+        /// @return @ref QueryData A tuple of std::optional containing the operands data if existing.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-21)
+        ///
+        template <size_t... ints>
+        QueryData getQueryData(size_t index, std::integer_sequence<size_t, ints...> int_seq)
+        {
+            (void)int_seq;
+            return std::make_tuple(
+                getOperandData(0, index), getOperandData(1, index), getOperandData(ints + 2, index)...);
+        }
+
+        ///
+        /// @brief Combine the current bitmask with the given one.
+        ///
+        /// @param[in] mask Evaluated bitmask.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-21)
+        ///
+        void combineMask(const util::BitSet &mask)
+        {
+            if (_mask.size() < mask.size())
+                _mask = util::BitSet(mask).inplaceAnd(_mask);
+            else
+                _mask.inplaceOr(mask);
+        }
+
+        ///
+        /// @brief Combine all the operands' bitmasks
+        ///
+        /// @tparam ints Sequence values.
+        ///
+        /// @param[in] int_seq Sequence containing the queryable ids.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-21)
+        ///
+        template <size_t... ints>
+        void combineOperandMasks(std::integer_sequence<size_t, ints...> int_seq)
+        {
+            (void)int_seq;
+            _mask = std::get<0>(_operands).getMask();
+            combineMask(getRight().getMask());
+            combineMask(std::get<ints + 2>(_operands).getMask()...);
+        }
+
+        Operands _operands;
         util::BitSet _mask;
     };
 } // namespace ecstasy::query::modifier

--- a/src/ecstasy/query/modifiers/Or.hpp
+++ b/src/ecstasy/query/modifiers/Or.hpp
@@ -65,7 +65,7 @@ namespace ecstasy::query::modifier
         /// The result is a binary Or between all the operands bitset's.
         ///
         /// @note @ref Queryable constraint.
-        /// @warning Use reload masks if the operand masks have changed since the construction.
+        /// @warning Use @ref reloadMask() if the operand masks have changed since the construction.
         ///
         /// @return const util::BitSet& resulting mask.
         ///
@@ -193,7 +193,7 @@ namespace ecstasy::query::modifier
         {
             (void)int_seq;
             _mask = std::get<0>(_operands).getMask();
-            combineMask(std::get<0>(_operands).getMask());
+            combineMask(std::get<1>(_operands).getMask());
             std::make_tuple((combineMask(std::get<ints + 2>(_operands).getMask()), 0)...);
         }
 

--- a/src/ecstasy/query/modifiers/Xor.hpp
+++ b/src/ecstasy/query/modifiers/Xor.hpp
@@ -19,56 +19,55 @@
 namespace ecstasy::query::modifier
 {
     ///
-    /// @brief Binary query modifier which performs a xor between two queryables.
+    /// @brief Binary query modifier which performs a xor between at least two queryables.
+    ///
+    /// @note The mask is the result of the operation: Q1 ^ Q2 ^ Qs...
+    /// @warning Since the mask of multiple operands is (Q1 ^ Q2) ^ Qs..., it is true when an odd number of operands
+    /// match a given id.
     ///
     /// @tparam Q1 Left operand queryable type.
     /// @tparam Q2 Right operand queryable type.
+    /// @tparam Qs Additional operand queryable types.
     ///
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-27)
     ///
-    template <Queryable Q1, Queryable Q2>
+    template <Queryable Q1, Queryable Q2, Queryable... Qs>
     class Xor : public BinaryModifier {
       public:
-        /// @brief Left operand type (queryable)
-        using LeftOperand = Q1;
-
-        /// @brief Left operand data type
-        using LeftQueryData = util::meta::add_optional_t<typename LeftOperand::QueryData>;
-
-        /// @brief Right operand type (queryable)
-        using RightOperand = Q2;
-
-        /// @brief Right operand data type
-        using RightQueryData = util::meta::add_optional_t<typename RightOperand::QueryData>;
-
-        /// @brief Wrapped queryables.
-        using Operands = std::tuple<Q1, Q2>;
+        /// @brief @ref Modifier constraint.
+        using Operands = std::tuple<Q1, Q2, Qs...>;
 
         /// @brief @ref Queryable constaint.
-        using QueryData = std::tuple<LeftQueryData, RightQueryData>;
+        // clang-format off
+        using QueryData = std::tuple<
+            util::meta::add_optional_t<typename Q1::QueryData>,
+            util::meta::add_optional_t<typename Q2::QueryData>,
+            util::meta::add_optional_t<typename Qs::QueryData>...>;
+        // clang-format on
 
         ///
         /// @brief Construct a new Xor Queryable modifier.
         ///
         /// @param[in] leftOperand left queryable operand.
         /// @param[in] rightOperand right queryable operand.
+        /// @param[in] otherOperands additional operands (optional).
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-10-27)
         ///
-        Xor(LeftOperand &leftOperand, RightOperand &rightOperand)
-            : _leftOperand(leftOperand), _rightOperand(rightOperand)
+        Xor(Q1 &firstOperand, Q2 &secondOperand, Qs &...otherOperands)
+            : _operands({firstOperand, secondOperand, otherOperands...})
         {
             reloadMask();
         }
 
         ///
-        /// @brief Get the Mask of the internal queryable.
-        /// The result is a binary Xor between the two operands bitset.
+        /// @brief Get the Mask of the internal queryables.
+        /// The result is a binary Or between all the operands bitset's.
         ///
         /// @note @ref Queryable constraint.
-        /// @warning Use reload masks if the operand masks have changed since the construction.
+        /// @warning Use @ref reloadMask() if the operand masks have changed since the construction.
         ///
         /// @return const util::BitSet& resulting mask.
         ///
@@ -81,47 +80,29 @@ namespace ecstasy::query::modifier
         }
 
         ///
-        /// @brief Get a std::optional filled with the data of the left operand at index @p index if existing.
+        /// @brief Get a std::optional filled with the data of the specified operand at index @p index if existing.
         ///
-        /// @warning May throw exceptions, look at the @b LeftOperand type equivalent method documentation.
+        /// @warning May throw exceptions, look at the specified operand type equivalent method documentation.
         ///
+        /// @param[in] operandId Id of the operand (where 0 is Q1, 1 is Q2...).
         /// @param[in] index Index of the entity.
         ///
-        /// @return @ref LeftQueryData A std::optional filled with the left operand data at index @p index if existing.
+        /// @return auto A std::optional filled with the resulting operand data at index @p index if existing.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-10-27)
         ///
-        LeftQueryData getLeftQueryData(size_t index)
+        auto getOperandData(size_t operandId, size_t index)
         {
-            if (index < _leftOperand.getMask().size() && _leftOperand.getMask()[index])
-                return LeftQueryData{_leftOperand.getQueryData(index)};
+            auto &operand = std::get<operandId>(_operands);
+
+            if (index < operand.getMask().size() && operand.getMask()[index])
+                return operand.getQueryData(index);
             return std::nullopt;
         }
 
         ///
-        /// @brief Get a std::optional filled with the data of the right operand at index @p index if existing.
-        ///
-        /// @warning May throw exceptions, look at the @b RightOperand type equivalent method documentation.
-        ///
-        /// @param[in] index Index of the entity.
-        ///
-        /// @return @ref RightQueryData A std::optional filled with the right operand data at index @p index if
-        /// existing.
-        ///
-        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
-        /// @since 1.0.0 (2022-10-27)
-        ///
-        RightQueryData getRightQueryData(size_t index)
-        {
-            if (index < _rightOperand.getMask().size() && _rightOperand.getMask()[index])
-                return RightQueryData{_rightOperand.getQueryData(index)};
-            return std::nullopt;
-        }
-
-        ///
-        /// @brief Get the operands data at the given index. The data are merged in a tuple containing the result of
-        /// @ref getLeftQueryData() and @ref getRightQueryData().
+        /// @brief Get the operands data at the given index.
         ///
         /// @note @ref Queryable constraint.
         ///
@@ -134,7 +115,7 @@ namespace ecstasy::query::modifier
         ///
         QueryData getQueryData(size_t index)
         {
-            return std::make_tuple(getLeftQueryData(index), getRightQueryData(index));
+            return getQueryData(index, std::make_index_sequence<(sizeof...(Qs))>());
         }
 
         ///
@@ -145,18 +126,80 @@ namespace ecstasy::query::modifier
         ///
         void reloadMask()
         {
-            if (_leftOperand.getMask().size() > _rightOperand.getMask().size()) {
-                _mask = _leftOperand.getMask();
-                _mask.inplaceXor(_rightOperand.getMask());
-            } else {
-                _mask = _rightOperand.getMask();
-                _mask.inplaceXor(_leftOperand.getMask());
+            if constexpr (sizeof...(Qs) > 0)
+                combineOperandMasks(std::make_index_sequence<(sizeof...(Qs))>());
+            else {
+                auto &leftOperand = std::get<0>(_operands);
+                auto &rightOperand = std::get<1>(_operands);
+
+                if (leftOperand.getMask().size() > rightOperand.getMask().size()) {
+                    _mask = leftOperand.getMask();
+                    _mask.inplaceXor(rightOperand.getMask());
+                } else {
+                    _mask = rightOperand.getMask();
+                    _mask.inplaceXor(leftOperand.getMask());
+                }
             }
         }
 
       private:
-        LeftOperand &_leftOperand;
-        RightOperand &_rightOperand;
+        ///
+        /// @brief Get the the query data.
+        ///
+        /// @tparam ints Sequence values.
+        ///
+        /// @param[in] index Id of the query data to fetch.
+        /// @param[in] int_seq Sequence containing the queryables ids.
+        ///
+        /// @return @ref QueryData A tuple of std::optional containing the operands data if existing.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-21)
+        ///
+        template <size_t... ints>
+        QueryData getQueryData(size_t index, std::integer_sequence<size_t, ints...> int_seq)
+        {
+            (void)int_seq;
+            return std::make_tuple(
+                getOperandData(0, index), getOperandData(1, index), getOperandData(ints + 2, index)...);
+        }
+
+        ///
+        /// @brief Combine the current bitmask with the given one.
+        ///
+        /// @param[in] mask Evaluated bitmask.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-21)
+        ///
+        void combineMask(const util::BitSet &mask)
+        {
+            if (_mask.size() < mask.size())
+                _mask = util::BitSet(mask).inplaceXor(_mask);
+            else
+                _mask.inplaceXor(mask);
+        }
+
+        ///
+        /// @brief Combine all the operands' bitmasks
+        ///
+        /// @tparam ints Sequence values.
+        ///
+        /// @param[in] int_seq Sequence containing the queryable ids.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-21)
+        ///
+        template <size_t... ints>
+        void combineOperandMasks(std::integer_sequence<size_t, ints...> int_seq)
+        {
+            (void)int_seq;
+            _mask = std::get<0>(_operands).getMask();
+            combineMask(std::get<1>(_operands).getMask());
+            std::make_tuple((combineMask(std::get<ints + 2>(_operands).getMask()), 0)...);
+        }
+
+        std::tuple<Q1 &, Q2 &, Qs &...> _operands;
         util::BitSet _mask;
     };
 } // namespace ecstasy::query::modifier

--- a/src/ecstasy/query/modifiers/Xor.hpp
+++ b/src/ecstasy/query/modifiers/Xor.hpp
@@ -33,7 +33,7 @@ namespace ecstasy::query::modifier
     /// @since 1.0.0 (2022-10-27)
     ///
     template <Queryable Q1, Queryable Q2, Queryable... Qs>
-    class Xor : public BinaryModifier {
+    class Xor : public Modifier {
       public:
         /// @brief @ref Modifier constraint.
         using Operands = std::tuple<Q1, Q2, Qs...>;

--- a/src/ecstasy/registry/Registry.hpp
+++ b/src/ecstasy/registry/Registry.hpp
@@ -88,16 +88,6 @@ namespace ecstasy
             return _storages.get<S>();
         }
 
-        /// @copydoc getQueryable()
-        template <std::derived_from<query::modifier::UnaryModifier> M>
-        requires query::Queryable<M>
-        constexpr M &getQueryable(OptionalModifiersAllocator &allocator)
-        {
-            if (!allocator)
-                throw std::logic_error("Missing modifier allocator");
-            return allocator->get().instanciate<M>(getQueryable<typename M::Internal>(allocator));
-        }
-
         ///
         /// @brief Proxy structure to extract the operand types using template partial specialization
         ///
@@ -136,8 +126,7 @@ namespace ecstasy
             /// @author Andréas Leroux (andreas.leroux@epitech.eu)
             /// @since 1.0.0 (2022-11-22)
             ///
-            template <std::derived_from<query::modifier::BinaryModifier> M>
-            requires query::Queryable<M>
+            template <query::Modifier M>
             static constexpr M &get(Registry &registry, OptionalModifiersAllocator &allocator)
             {
                 if (!allocator)
@@ -147,8 +136,7 @@ namespace ecstasy
         };
 
         /// @copydoc getQueryable()
-        template <std::derived_from<query::modifier::BinaryModifier> M>
-        requires query::Queryable<M>
+        template <query::Modifier M>
         constexpr M &getQueryable(OptionalModifiersAllocator &allocator)
         {
             return GetModifierProxy<typename M::Operands>::template get<M>(*this, allocator);
@@ -156,7 +144,6 @@ namespace ecstasy
 
         /// @copydoc getQueryable()
         template <RegistryModifier M>
-        requires query::Queryable<typename M::Modifier>
         constexpr typename M::Modifier &getQueryable(OptionalModifiersAllocator &allocator)
         {
             return getQueryable<typename M::Modifier>(allocator);

--- a/src/ecstasy/registry/Registry.hpp
+++ b/src/ecstasy/registry/Registry.hpp
@@ -51,8 +51,13 @@ namespace ecstasy
         ///
         /// @tparam C Type of the variable to fetch.
         ///
+        /// @param[in] allocator Allocator to instanciate query modifier. Can be empty if no modifier needs to be
+        /// instanciated.
+        ///
         /// @return @ref getStorageType<C>& Associated queryable (if no specific case the storage for C is
         /// returned).
+        ///
+        /// @throw std::logic_error When @p allocator is empty and the queryable needs to be allocated.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-10-25)
@@ -93,15 +98,60 @@ namespace ecstasy
             return allocator->get().instanciate<M>(getQueryable<typename M::Internal>(allocator));
         }
 
+        ///
+        /// @brief Proxy structure to extract the operand types using template partial specialization
+        ///
+        /// @tparam Operands Must be a tuple of @ref Queryable types.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-22)
+        ///
+        template <typename Operands>
+        struct GetModifierProxy {
+        };
+
+        ///
+        /// @brief Proxy structure to extract the operand types using template partial specialization
+        ///
+        /// @tparam Qs Operands types of the modifier.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-11-22)
+        ///
+        template <query::Queryable... Qs>
+        struct GetModifierProxy<std::tuple<Qs...>> {
+            ///
+            /// @brief Specialization of @ref Registry::getQueryable(). Returns the required modifier with the operands
+            /// queried from the registry.
+            ///
+            /// @tparam M Modifier type.
+            ///
+            /// @param[in] registry Owning registry.
+            /// @param[in] allocator Allocator to instanciate the modifier. Must not be empty.
+            ///
+            /// @return M& Required modifier.
+            ///
+            /// @throw std::logic_error When @p allocator is empty.
+            ///
+            /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+            /// @since 1.0.0 (2022-11-22)
+            ///
+            template <std::derived_from<query::modifier::BinaryModifier> M>
+            requires query::Queryable<M>
+            static constexpr M &get(Registry &registry, OptionalModifiersAllocator &allocator)
+            {
+                if (!allocator)
+                    throw std::logic_error("Missing modifier allocator");
+                return allocator->get().instanciate<M>(registry.getQueryable<Qs>(allocator)...);
+            }
+        };
+
         /// @copydoc getQueryable()
         template <std::derived_from<query::modifier::BinaryModifier> M>
         requires query::Queryable<M>
         constexpr M &getQueryable(OptionalModifiersAllocator &allocator)
         {
-            if (!allocator)
-                throw std::logic_error("Missing modifier allocator");
-            return allocator->get().instanciate<M>(
-                getQueryable<typename M::LeftOperand>(allocator), getQueryable<typename M::RightOperand>(allocator));
+            return GetModifierProxy<typename M::Operands>::template get<M>(*this, allocator);
         }
 
         /// @copydoc getQueryable()

--- a/src/ecstasy/registry/concepts/RegistryModifier.hpp
+++ b/src/ecstasy/registry/concepts/RegistryModifier.hpp
@@ -12,8 +12,7 @@
 #ifndef ECSTASY_REGISTRY_CONCEPTS_REGISTRYMODIFIER_HPP_
 #define ECSTASY_REGISTRY_CONCEPTS_REGISTRYMODIFIER_HPP_
 
-#include "ecstasy/query/concepts/Queryable.hpp"
-#include "ecstasy/query/modifiers/Modifier.hpp"
+#include "ecstasy/query/concepts/Modifier.hpp"
 #include "util/Allocator.hpp"
 
 namespace ecstasy
@@ -30,7 +29,7 @@ namespace ecstasy
     concept RegistryModifier = requires()
     {
         typename M::Modifier;
-        requires query::Queryable<typename M::Modifier>;
+        requires query::Modifier<typename M::Modifier>;
     };
 
 } // namespace ecstasy

--- a/src/ecstasy/registry/modifiers/And.hpp
+++ b/src/ecstasy/registry/modifiers/And.hpp
@@ -22,13 +22,14 @@ namespace ecstasy
     ///
     /// @tparam C1 left operand type.
     /// @tparam C2 right operand type.
+    /// @tparam Cs additional operand types.
     ///
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-24)
     ///
-    template <typename C1, typename C2>
+    template <typename C1, typename C2, typename... Cs>
     struct And {
-        using Modifier = query::modifier::And<queryable_type_t<C1>, queryable_type_t<C2>>;
+        using Modifier = query::modifier::And<queryable_type_t<C1>, queryable_type_t<C2>, queryable_type_t<Cs>...>;
     };
 } // namespace ecstasy
 

--- a/src/ecstasy/registry/modifiers/Or.hpp
+++ b/src/ecstasy/registry/modifiers/Or.hpp
@@ -21,13 +21,14 @@ namespace ecstasy
     ///
     /// @tparam C1 left operand type.
     /// @tparam C2 right operand type.
+    /// @tparam Cs additional operand types.
     ///
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-24)
     ///
-    template <typename C1, typename C2>
+    template <typename C1, typename C2, typename... Cs>
     struct Or {
-        using Modifier = query::modifier::Or<queryable_type_t<C1>, queryable_type_t<C2>>;
+        using Modifier = query::modifier::Or<queryable_type_t<C1>, queryable_type_t<C2>, queryable_type_t<Cs>...>;
     };
 } // namespace ecstasy
 

--- a/src/ecstasy/registry/modifiers/Xor.hpp
+++ b/src/ecstasy/registry/modifiers/Xor.hpp
@@ -21,13 +21,14 @@ namespace ecstasy
     ///
     /// @tparam C1 left operand type.
     /// @tparam C2 right operand type.
+    /// @tparam Cs additional operand types.
     ///
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-24)
     ///
-    template <typename C1, typename C2>
+    template <typename C1, typename C2, typename... Cs>
     struct Xor {
-        using Modifier = query::modifier::Xor<queryable_type_t<C1>, queryable_type_t<C2>>;
+        using Modifier = query::modifier::Xor<queryable_type_t<C1>, queryable_type_t<C2>, queryable_type_t<Cs>...>;
     };
 } // namespace ecstasy
 

--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -438,3 +438,27 @@ TEST(Query, parameter_orders)
     auto query2 = ecstasy::query::Select<decltype(positions), decltype(velocities), decltype(vectors)>::where(
         vectors, velocities, positions);
 }
+
+TEST(Query, OrVariadic)
+{
+    ecstasy::MapStorage<Position> positions;
+    ecstasy::MapStorage<Velocity> velocities;
+    ecstasy::MapStorage<Vector2i> vectors;
+    ecstasy::Entities entities;
+    auto velocityOrVector = ecstasy::query::modifier::Or(positions, velocities, vectors);
+    auto maybeVector = ecstasy::query::modifier::Maybe(vectors);
+
+    for (int i = 0; i < 13; i++) {
+        entities.create();
+        if (i % 2 == 0)
+            positions.emplace(i, i * 2, i * 10);
+        if (i % 3 == 0 || i == 8)
+            velocities.emplace(i, i * 10, i * 2);
+        if (i % 4 == 0)
+            vectors.emplace(i, i * 4, i * 6);
+    }
+
+    velocityOrVector.reloadMask();
+    auto query = ecstasy::query::Select<decltype(maybeVector)>::where(maybeVector, velocityOrVector);
+    GTEST_ASSERT_EQ(query.getMask(), util::BitSet("11011101011101"));
+}


### PR DESCRIPTION
# Description

Allow to add more than 2 operands to binary query modifiers (Or, And, Xor).
Also removed the Binary/Unary Modifier difference.

Introduce new ecstasy::query::Modifier concept defining constraint for a query modifier type.

Close #76 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tiny new tests have been written.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
