### PR TITLE
Feature/97 query runtime conditions

### DIFF
--- a/src/ecstasy/query/CMakeLists.txt
+++ b/src/ecstasy/query/CMakeLists.txt
@@ -2,6 +2,7 @@ set(INCROOT ${INCROOT}/query)
 set(SRCROOT ${SRCROOT}/query)
 
 add_subdirectory(concepts)
+add_subdirectory(conditions)
 add_subdirectory(modifiers)
 
 set(SRC

--- a/src/ecstasy/query/Select.hpp
+++ b/src/ecstasy/query/Select.hpp
@@ -241,19 +241,22 @@ namespace ecstasy::query
         ///
         /// @warning All queryables specified in @ref Selected @b must be passed as parameters.
         ///
+        /// @tparam Conditions @ref util::meta::Traits of multiple @ref ecstasy::query::Condition.
         /// @tparam FirstWhere First @ref Queryable type.
         /// @tparam Wheres Others @ref Queryable types.
         ///
         /// @param[in] firstWhere first @ref Queryable instance.
         /// @param[in] wheres others @ref Queryable instances.
         ///
-        /// @return Query<SelectedQueryables...> Resulting query that can be iterated.
+        /// @return QueryImplementation<util::meta::Traits<SelectedQueryables...>, Conditions> Resulting query that can
+        /// be iterated.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-10-22)
         ///
-        template <Queryable FirstWhere, Queryable... Wheres>
-        static Query<SelectedQueryables...> where(FirstWhere &firstWhere, Wheres &...wheres)
+        template <typename Conditions = util::meta::Traits<>, Queryable FirstWhere, Queryable... Wheres>
+        static QueryImplementation<util::meta::Traits<SelectedQueryables...>, Conditions> where(
+            FirstWhere &firstWhere, Wheres &...wheres)
         {
             /// Adjusts the masks only if required
             if constexpr (is_queryable_with_adjust_v<
@@ -266,7 +269,8 @@ namespace ecstasy::query
 
             util::BitSet mask = (util::BitSet(firstWhere.getMask()) &= ... &= wheres.getMask());
 
-            return Query<SelectedQueryables...>(mask, filterQueryables(firstWhere, wheres...));
+            return QueryImplementation<util::meta::Traits<SelectedQueryables...>, Conditions>(
+                mask, filterQueryables(firstWhere, wheres...));
         }
     };
 

--- a/src/ecstasy/query/concepts/Condition.hpp
+++ b/src/ecstasy/query/concepts/Condition.hpp
@@ -33,7 +33,7 @@ namespace ecstasy::query
     };
 
     template <typename C>
-    concept QConditionLeft = requires(C &condition, const C::Left &left)
+    concept QConditionLeft = requires(C &condition, const typename C::Left &left)
     {
         requires QCondition<C>;
 
@@ -45,7 +45,7 @@ namespace ecstasy::query
     };
 
     template <typename C>
-    concept QConditionRight = requires(C &condition, const C::Right &right)
+    concept QConditionRight = requires(C &condition, const typename C::Right &right)
     {
         requires QCondition<C>;
 
@@ -57,7 +57,7 @@ namespace ecstasy::query
     };
 
     template <typename C>
-    concept QConditionLeftRight = requires(C &condition, const C::Left &left, const C::Right &right)
+    concept QConditionLeftRight = requires(C &condition, const typename C::Left &left, const typename C::Right &right)
     {
         requires QCondition<C>;
 

--- a/src/ecstasy/query/concepts/Condition.hpp
+++ b/src/ecstasy/query/concepts/Condition.hpp
@@ -1,0 +1,73 @@
+///
+/// @file Condition.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONCEPTS_CONDITION_HPP_
+#define ECSTASY_QUERY_CONCEPTS_CONDITION_HPP_
+
+#include "ecstasy/query/conditions/Condition.hpp"
+
+namespace ecstasy::query
+{
+    template <typename C>
+    concept QCondition = requires(C &condition)
+    {
+        requires std::derived_from<C, ecstasy::query::ConditionBase>;
+    };
+
+    template <typename C>
+    concept QConditionConst = requires(C &condition)
+    {
+        requires QCondition<C>;
+
+        // clang-format off
+        { C::test() } -> std::same_as<bool>;
+        // clang-format on
+    };
+
+    template <typename C>
+    concept QConditionLeft = requires(C &condition, const C::Left &left)
+    {
+        requires QCondition<C>;
+
+        typename C::Left;
+
+        // clang-format off
+        { C::test(left) } -> std::same_as<bool>;
+        // clang-format on
+    };
+
+    template <typename C>
+    concept QConditionRight = requires(C &condition, const C::Right &right)
+    {
+        requires QCondition<C>;
+
+        typename C::Right;
+
+        // clang-format off
+        { C::test(right) } -> std::same_as<bool>;
+        // clang-format on
+    };
+
+    template <typename C>
+    concept QConditionLeftRight = requires(C &condition, const C::Left &left, const C::Right &right)
+    {
+        requires QCondition<C>;
+
+        typename C::Left;
+        typename C::Right;
+
+        // clang-format off
+        { C::test(left, right) } -> std::same_as<bool>;
+        // clang-format on
+    };
+} // namespace ecstasy::query
+
+#endif /* !ECSTASY_QUERY_CONCEPTS_CONDITION_HPP_ */

--- a/src/ecstasy/query/concepts/include.hpp
+++ b/src/ecstasy/query/concepts/include.hpp
@@ -12,6 +12,7 @@
 #ifndef ECSTASY_QUERY_CONCEPTS_HPP_
 #define ECSTASY_QUERY_CONCEPTS_HPP_
 
+#include "Condition.hpp"
 #include "Modifier.hpp"
 #include "Queryable.hpp"
 #include "QueryableNeedAdjust.hpp"

--- a/src/ecstasy/query/conditions/CMakeLists.txt
+++ b/src/ecstasy/query/conditions/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(INCROOT ${INCROOT}/conditions)
+set(SRCROOT ${SRCROOT}/conditions)
+
+set(SRC
+    ${SRC}
+    ${INCROOT}/Condition.hpp
+    PARENT_SCOPE
+)

--- a/src/ecstasy/query/conditions/Condition.hpp
+++ b/src/ecstasy/query/conditions/Condition.hpp
@@ -16,13 +16,15 @@
 
 namespace ecstasy::query
 {
+    struct ConditionBase {};
+
     template <auto Left, auto Right, typename Comparer>
-    struct Condition {
+    struct Condition : public ConditionBase {
     };
 
     template <typename LeftType, typename LeftValueType, LeftValueType LeftType::*ptr, typename RightType,
         RightType Right, typename Comparer>
-    requires(!std::is_function_v<LeftValueType>) struct Condition<ptr, Right, Comparer> {
+    requires(!std::is_function_v<LeftValueType>) struct Condition<ptr, Right, Comparer> : public ConditionBase {
         using Left = LeftType;
 
         static bool test(const LeftType &left)
@@ -33,7 +35,7 @@ namespace ecstasy::query
 
     template <typename LeftType, typename LeftValueType, LeftValueType (LeftType::*ptr)(void) const, typename RightType,
         RightType Right, typename Comparer>
-    struct Condition<ptr, Right, Comparer> {
+    struct Condition<ptr, Right, Comparer> : public ConditionBase {
         static bool test(const LeftType &left)
         {
             return Comparer{}((left.*ptr)(), Right);

--- a/src/ecstasy/query/conditions/Condition.hpp
+++ b/src/ecstasy/query/conditions/Condition.hpp
@@ -1,0 +1,46 @@
+///
+/// @file Condition.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-15
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_CONDITION_HPP_
+#define ECSTASY_QUERY_CONDITIONS_CONDITION_HPP_
+
+#include <concepts>
+
+namespace ecstasy::query
+{
+    template <auto Left, auto Right, typename Comparer>
+    struct Condition {
+    };
+
+    template <typename LeftType, typename LeftValueType, LeftValueType LeftType::*Left, typename RightType,
+        RightType Right, typename Comparer>
+    requires(!std::is_function_v<LeftValueType>) struct Condition<Left, Right, Comparer> {
+        Condition() = default;
+
+        bool operator()(const LeftType &left)
+        {
+            return Comparer{}(left.*Left, Right);
+        }
+    };
+
+    template <typename LeftType, typename LeftValueType, LeftValueType (LeftType::*Left)(void) const,
+        typename RightType, RightType Right, typename Comparer>
+    struct Condition<Left, Right, Comparer> {
+        Condition() = default;
+
+        bool operator()(const LeftType &left)
+        {
+            return Comparer{}((left.*Left)(), Right);
+        }
+    };
+} // namespace ecstasy::query
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_CONDITION_HPP_ */

--- a/src/ecstasy/query/conditions/Condition.hpp
+++ b/src/ecstasy/query/conditions/Condition.hpp
@@ -22,9 +22,64 @@ namespace ecstasy::query
     struct Condition : public ConditionBase {
     };
 
-    template <typename LeftType, typename LeftValueType, LeftValueType LeftType::*ptr, typename RightType,
-        RightType Right, typename Comparer>
-    requires(!std::is_function_v<LeftValueType>) struct Condition<ptr, Right, Comparer> : public ConditionBase {
+    /// @note Const - Const, Will therefore always output the same result
+    // clang-format off
+    template <
+        typename LeftType, LeftType Left, 
+        typename RightType, RightType Right, 
+        typename Comparer>
+    requires(!std::is_member_pointer_v<LeftType> && !std::is_member_pointer_v<RightType>) 
+    struct Condition<Left, Right, Comparer> : public ConditionBase {
+        //clang-format on
+        static bool test()
+        {
+            return Comparer{}(Left, Right);
+        }
+    };
+
+    /// @note Const - Member
+    // clang-format off
+    template <
+        typename LeftType, LeftType Left, 
+        typename RightType, typename RightValueType, RightValueType RightType::*ptr, 
+        typename Comparer>
+    requires(!std::is_member_pointer_v<LeftType> && std::is_member_object_pointer_v<decltype(ptr)>) 
+        struct Condition<Left, ptr, Comparer> : public ConditionBase {
+        //clang-format on
+        using Right = RightType;
+
+        static bool test(const RightType &right)
+        {
+            return Comparer{}(Left, right.*ptr);
+        }
+    };
+
+    /// @note Const - Getter
+    // clang-format off
+    template <
+        typename LeftType, LeftType Left, 
+        typename RightType, typename RightValueType, RightValueType (RightType::*ptr)(void) const, 
+        typename Comparer>
+    requires(!std::is_member_pointer_v<LeftType> && std::is_member_function_pointer_v<decltype(ptr)>) 
+        struct Condition<Left, ptr, Comparer> : public ConditionBase {
+        // clang-format on
+        using Right = RightType;
+
+        static bool test(const RightType &right)
+        {
+            return Comparer{}(Left, (right.*ptr)());
+        }
+    };
+
+    /// @note Member - Const
+    // clang-format off
+    template <
+        typename LeftType, typename LeftValueType, LeftValueType LeftType::*ptr, 
+        typename RightType, RightType Right, 
+        typename Comparer>
+    requires(std::is_member_object_pointer_v<decltype(ptr)> && !std::is_member_pointer_v<RightType>) 
+    struct Condition<ptr, Right, Comparer> : public ConditionBase {
+        // clang-format on
         using Left = LeftType;
 
         static bool test(const LeftType &left)
@@ -33,12 +88,92 @@ namespace ecstasy::query
         }
     };
 
-    template <typename LeftType, typename LeftValueType, LeftValueType (LeftType::*ptr)(void) const, typename RightType,
-        RightType Right, typename Comparer>
+    /// @note Member - Member
+    // clang-format off
+    template <
+        typename LeftType, typename LeftValueType, LeftValueType LeftType::*ptrLeft, 
+        typename RightType, typename RightValueType, RightValueType RightType::*ptrRight, 
+        typename Comparer>
+    requires(std::is_member_object_pointer_v<decltype(ptrLeft)> && std::is_member_object_pointer_v<decltype(ptrRight)>) 
+    struct Condition<ptrLeft, ptrRight, Comparer> : public ConditionBase {
+        // clang-format on
+        using Left = LeftType;
+        using Right = RightType;
+
+        static bool test(const LeftType &left, const RightType &right)
+        {
+            return Comparer{}(left.*ptrLeft, right.*ptrRight);
+        }
+    };
+
+    /// @note Member - Getter
+    // clang-format off
+    template <
+        typename LeftType, typename LeftValueType, LeftValueType LeftType::*ptrLeft, 
+        typename RightType, typename RightValueType, RightValueType (RightType::*ptrRight)(void) const, 
+        typename Comparer>
+    requires(std::is_member_object_pointer_v<decltype(ptrLeft)> && std::is_member_function_pointer_v<decltype(ptrRight)>) 
+    struct Condition<ptrLeft, ptrRight, Comparer> : public ConditionBase {
+        // clang-format on
+        using Left = LeftType;
+        using Right = RightType;
+
+        static bool test(const LeftType &left, const RightType &right)
+        {
+            return Comparer{}(left.*ptrLeft, (right.*ptrRight)());
+        }
+    };
+
+    /// @note Getter - Const
+    // clang-format off
+    template <
+        typename LeftType, typename LeftValueType, LeftValueType (LeftType::*ptr)(void) const, 
+        typename RightType, RightType Right, 
+        typename Comparer>
+    requires(std::is_member_function_pointer_v<decltype(ptr)> && !std::is_member_pointer_v<RightType>) 
     struct Condition<ptr, Right, Comparer> : public ConditionBase {
+        // clang-format on
+        using Left = LeftType;
+
         static bool test(const LeftType &left)
         {
             return Comparer{}((left.*ptr)(), Right);
+        }
+    };
+
+    /// @note Getter - Member
+    // clang-format off
+    template <
+        typename LeftType, typename LeftValueType, LeftValueType (LeftType::*ptrLeft)(void) const, 
+        typename RightType, typename RightValueType, RightValueType RightType::*ptrRight, 
+        typename Comparer>
+    requires(std::is_member_function_pointer_v<decltype(ptrLeft)> && std::is_member_object_pointer_v<decltype(ptrRight)>) 
+    struct Condition<ptrLeft, ptrRight, Comparer> : public ConditionBase {
+        // clang-format on
+        using Left = LeftType;
+        using Right = RightType;
+
+        static bool test(const LeftType &left, const RightType &right)
+        {
+            return Comparer{}((left.*ptrLeft)(), right.*ptrRight);
+        }
+    };
+
+    /// @note Getter - Getter
+    // clang-format off
+    template <
+        typename LeftType, typename LeftValueType, LeftValueType (LeftType::*ptrLeft)(void) const, 
+        typename RightType, typename RightValueType, RightValueType (RightType::*ptrRight)(void) const, 
+        typename Comparer>
+    requires(std::is_member_function_pointer_v<decltype(ptrLeft)> && std::is_member_function_pointer_v<decltype(ptrRight)>) 
+    struct Condition<ptrLeft, ptrRight, Comparer> : public ConditionBase {
+        // clang-format on
+        using Left = LeftType;
+        using Right = RightType;
+
+        static bool test(const LeftType &left, const RightType &right)
+        {
+            return Comparer{}((left.*ptrLeft)(), (right.*ptrRight)());
         }
     };
 } // namespace ecstasy::query

--- a/src/ecstasy/query/conditions/Condition.hpp
+++ b/src/ecstasy/query/conditions/Condition.hpp
@@ -20,25 +20,23 @@ namespace ecstasy::query
     struct Condition {
     };
 
-    template <typename LeftType, typename LeftValueType, LeftValueType LeftType::*Left, typename RightType,
+    template <typename LeftType, typename LeftValueType, LeftValueType LeftType::*ptr, typename RightType,
         RightType Right, typename Comparer>
-    requires(!std::is_function_v<LeftValueType>) struct Condition<Left, Right, Comparer> {
-        Condition() = default;
+    requires(!std::is_function_v<LeftValueType>) struct Condition<ptr, Right, Comparer> {
+        using Left = LeftType;
 
-        bool operator()(const LeftType &left)
+        static bool test(const LeftType &left)
         {
-            return Comparer{}(left.*Left, Right);
+            return Comparer{}(left.*ptr, Right);
         }
     };
 
-    template <typename LeftType, typename LeftValueType, LeftValueType (LeftType::*Left)(void) const,
-        typename RightType, RightType Right, typename Comparer>
-    struct Condition<Left, Right, Comparer> {
-        Condition() = default;
-
-        bool operator()(const LeftType &left)
+    template <typename LeftType, typename LeftValueType, LeftValueType (LeftType::*ptr)(void) const, typename RightType,
+        RightType Right, typename Comparer>
+    struct Condition<ptr, Right, Comparer> {
+        static bool test(const LeftType &left)
         {
-            return Comparer{}((left.*Left)(), Right);
+            return Comparer{}((left.*ptr)(), Right);
         }
     };
 } // namespace ecstasy::query

--- a/src/ecstasy/query/conditions/EqualTo.hpp
+++ b/src/ecstasy/query/conditions/EqualTo.hpp
@@ -1,0 +1,24 @@
+///
+/// @file EqualTo.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_EQUALTO_HPP_
+#define ECSTASY_QUERY_CONDITIONS_EQUALTO_HPP_
+
+#include "Condition.hpp"
+
+namespace ecstasy
+{
+    /// @brief Equality condition.
+    template <auto Left, auto Right>
+    using EqualTo = query::Condition<Left, Right, std::equal_to<>>;
+} // namespace ecstasy
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_EQUALTO_HPP_ */

--- a/src/ecstasy/query/conditions/Greater.hpp
+++ b/src/ecstasy/query/conditions/Greater.hpp
@@ -1,0 +1,24 @@
+///
+/// @file Greater.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_GREATER_HPP_
+#define ECSTASY_QUERY_CONDITIONS_GREATER_HPP_
+
+#include "Condition.hpp"
+
+namespace ecstasy
+{
+    /// @brief Greater than condition.
+    template <auto Left, auto Right>
+    using Greater = query::Condition<Left, Right, std::greater<>>;
+} // namespace ecstasy
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_GREATER_HPP_ */

--- a/src/ecstasy/query/conditions/GreaterEqual.hpp
+++ b/src/ecstasy/query/conditions/GreaterEqual.hpp
@@ -1,0 +1,24 @@
+///
+/// @file GreaterEqual.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_GREATEREQUAL_HPP_
+#define ECSTASY_QUERY_CONDITIONS_GREATEREQUAL_HPP_
+
+#include "Condition.hpp"
+
+namespace ecstasy
+{
+    /// @brief Greater than or equal condition.
+    template <auto Left, auto Right>
+    using GreaterEqual = query::Condition<Left, Right, std::greater_equal<>>;
+} // namespace ecstasy
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_GREATEREQUAL_HPP_ */

--- a/src/ecstasy/query/conditions/Less.hpp
+++ b/src/ecstasy/query/conditions/Less.hpp
@@ -1,0 +1,24 @@
+///
+/// @file Less.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_LESS_HPP_
+#define ECSTASY_QUERY_CONDITIONS_LESS_HPP_
+
+#include "Condition.hpp"
+
+namespace ecstasy
+{
+    /// @brief Less than condition.
+    template <auto Left, auto Right>
+    using Less = query::Condition<Left, Right, std::less<>>;
+} // namespace ecstasy
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_LESS_HPP_ */

--- a/src/ecstasy/query/conditions/LessEqual.hpp
+++ b/src/ecstasy/query/conditions/LessEqual.hpp
@@ -1,0 +1,24 @@
+///
+/// @file LessEqual.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_LESSEQUAL_HPP_
+#define ECSTASY_QUERY_CONDITIONS_LESSEQUAL_HPP_
+
+#include "Condition.hpp"
+
+namespace ecstasy
+{
+    /// @brief Less than or equal condition.
+    template <auto Left, auto Right>
+    using LessEqual = query::Condition<Left, Right, std::less_equal<>>;
+} // namespace ecstasy
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_LESSEQUAL_HPP_ */

--- a/src/ecstasy/query/conditions/NotEqualTo.hpp
+++ b/src/ecstasy/query/conditions/NotEqualTo.hpp
@@ -1,0 +1,24 @@
+///
+/// @file NotEqualTo.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-16
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_NOTEQUALTO_HPP_
+#define ECSTASY_QUERY_CONDITIONS_NOTEQUALTO_HPP_
+
+#include "Condition.hpp"
+
+namespace ecstasy
+{
+    /// @brief Inequality condition.
+    template <auto Left, auto Right>
+    using NotEqualTo = query::Condition<Left, Right, std::not_equal_to<>>;
+} // namespace ecstasy
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_NOTEQUALTO_HPP_ */

--- a/src/ecstasy/query/conditions/include.hpp
+++ b/src/ecstasy/query/conditions/include.hpp
@@ -1,0 +1,23 @@
+///
+/// @file include.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-11-18
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_QUERY_CONDITIONS_HPP_
+#define ECSTASY_QUERY_CONDITIONS_HPP_
+
+#include "Condition.hpp"
+#include "EqualTo.hpp"
+#include "Greater.hpp"
+#include "GreaterEqual.hpp"
+#include "Less.hpp"
+#include "LessEqual.hpp"
+#include "NotEqualTo.hpp"
+
+#endif /* !ECSTASY_QUERY_CONDITIONS_HPP_ */

--- a/src/util/meta/CMakeLists.txt
+++ b/src/util/meta/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
     ${SRC}
     ${INCROOT}/add_optional.hpp
     ${INCROOT}/contains.hpp
+    ${INCROOT}/index.hpp
     ${INCROOT}/outer_join.hpp
     ${INCROOT}/Traits.hpp
     ${INCROOT}/type_set_eq.hpp

--- a/src/util/meta/apply.hpp
+++ b/src/util/meta/apply.hpp
@@ -1,0 +1,56 @@
+///
+/// @file apply.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-15
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef UTIL_META_APPLY_HPP_
+#define UTIL_META_APPLY_HPP_
+
+#include "Traits.hpp"
+
+namespace util::meta
+{
+    ///
+    /// @brief Apply a modification on all types in @p Ts.
+    ///
+    /// @note Result is a structure with a @b type alias defined to a @ref util::meta::Traits containing the modified
+    /// types.
+    ///
+    /// @tparam Functor Templated type to apply on @p Ts types. (Ex: @ref std::referece_wrapper, or @ref
+    /// std::remove_reference)
+    /// @tparam Ts Types to modify.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-12-16)
+    ///
+    template <template <typename> typename Functor, typename... Ts>
+    struct apply {
+        using type = Traits<Functor<Ts>...>;
+    };
+
+    /// @copydoc apply
+    template <template <typename> typename Functor, typename... Ts>
+    struct apply<Functor, Traits<Ts...>> {
+        using type = Traits<Functor<Ts>...>;
+    };
+
+    ///
+    /// @brief Helper for apply<...>::type.
+    ///
+    /// @tparam Functor functor.
+    /// @tparam Ts Types to modify.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-10-29)
+    ///
+    template <template <typename> typename Functor, typename... Ts>
+    using apply_t = apply<Functor, Ts...>::type;
+} // namespace util::meta
+
+#endif /* !UTIL_META_APPLY_HPP_ */

--- a/src/util/meta/apply.hpp
+++ b/src/util/meta/apply.hpp
@@ -50,7 +50,7 @@ namespace util::meta
     /// @since 1.0.0 (2022-10-29)
     ///
     template <template <typename> typename Functor, typename... Ts>
-    using apply_t = apply<Functor, Ts...>::type;
+    using apply_t = typename apply<Functor, Ts...>::type;
 } // namespace util::meta
 
 #endif /* !UTIL_META_APPLY_HPP_ */

--- a/src/util/meta/filter.hpp
+++ b/src/util/meta/filter.hpp
@@ -1,0 +1,86 @@
+///
+/// @file filter.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-12-15
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef UTIL_META_FILTER_HPP_
+#define UTIL_META_FILTER_HPP_
+
+#include "Traits.hpp"
+
+namespace util::meta
+{
+    /// @internal
+    /// @brief Internal @ref filter struct.
+    ///
+    /// @note Resulting type is a @ref util::meta::Traits containing the types from @p Untreated for which
+    /// Filter<T>::value was true.
+    ///
+    /// @tparam Treated @ref Must be a @ref util::meta::Traits of types already filtered.
+    /// @tparam Filter Filter type, must contains a boolean value element (as in @ref std::true_type and @ref
+    /// std::false_type).
+    /// @tparam Untreated Types to filter.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-12-16)
+    ///
+    template <typename Treated, template <typename> typename Filter, typename... Untreated>
+    struct _filter {
+        using type = Traits<>;
+    };
+
+    /// @copydoc _filter
+    /// @note End condition, no more types to filter.
+    template <typename... Treated, template <typename> typename Filter>
+    struct _filter<Traits<Treated...>, Filter> {
+        using type = Traits<Treated...>;
+    };
+
+    /// @copydoc _filter
+    /// @note Loop condition, treat type @p Current.
+    template <typename... Treated, template <typename> typename Filter, typename Current, typename... Untreated>
+    struct _filter<Traits<Treated...>, Filter, Current, Untreated...> {
+        using type =
+            _filter<std::conditional_t<Filter<Current>::value, Traits<Treated..., Current>, Traits<Treated...>>, Filter,
+                Untreated...>::type;
+    };
+
+    ///
+    /// @brief Filter the types in @p Ts keeping only those for which Filter<T>::value was true.
+    ///
+    /// @note Resulting type is a @ref util::meta::Traits containing the types from @p Untreated for which
+    /// Filter<T>::value was true.
+    ///
+    /// @tparam Filter Filter type, must contains a boolean value element (as in @ref std::true_type and @ref
+    /// std::false_type).
+    /// @tparam Ts Types to filter
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-12-16)
+    ///
+    template <template <typename> typename Filter, typename... Ts>
+    struct filter {
+        using type = _filter<Traits<>, Filter, Ts...>::type;
+    };
+
+    ///
+    /// @brief Helper for filter<...>::type.
+    ///
+    /// @tparam Filter filter.
+    /// @tparam Ts Types to filter.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-10-29)
+    ///
+    template <template <typename> typename Filter, typename... Ts>
+    using filter_t = filter<Filter, Ts...>::type;
+
+} // namespace util::meta
+
+#endif /* !UTIL_META_FILTER_HPP_ */

--- a/src/util/meta/filter.hpp
+++ b/src/util/meta/filter.hpp
@@ -46,9 +46,9 @@ namespace util::meta
     /// @note Loop condition, treat type @p Current.
     template <typename... Treated, template <typename> typename Filter, typename Current, typename... Untreated>
     struct _filter<Traits<Treated...>, Filter, Current, Untreated...> {
-        using type =
-            _filter<std::conditional_t<Filter<Current>::value, Traits<Treated..., Current>, Traits<Treated...>>, Filter,
-                Untreated...>::type;
+        using type = typename _filter<
+            std::conditional_t<Filter<Current>::value, Traits<Treated..., Current>, Traits<Treated...>>, Filter,
+            Untreated...>::type;
     };
 
     ///
@@ -66,7 +66,7 @@ namespace util::meta
     ///
     template <template <typename> typename Filter, typename... Ts>
     struct filter {
-        using type = _filter<Traits<>, Filter, Ts...>::type;
+        using type = typename _filter<Traits<>, Filter, Ts...>::type;
     };
 
     ///
@@ -79,7 +79,7 @@ namespace util::meta
     /// @since 1.0.0 (2022-10-29)
     ///
     template <template <typename> typename Filter, typename... Ts>
-    using filter_t = filter<Filter, Ts...>::type;
+    using filter_t = typename filter<Filter, Ts...>::type;
 
 } // namespace util::meta
 

--- a/src/util/meta/index.hpp
+++ b/src/util/meta/index.hpp
@@ -41,7 +41,7 @@ namespace util::meta
     };
 
     ///
-    /// @brief Helper for right_outer_join<...>::type.
+    /// @brief Helper for index<...>::type.
     ///
     /// @tparam T Searched type.
     /// @tparam Ts Types containing @p T.

--- a/src/util/meta/index.hpp
+++ b/src/util/meta/index.hpp
@@ -1,0 +1,57 @@
+///
+/// @file find.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2022-10-28
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef UTIL_META_FIND_HPP_
+#define UTIL_META_FIND_HPP_
+
+#include <type_traits>
+
+namespace util::meta
+{
+    ///
+    /// @brief Get the index of the first occurence of type @p T in the types @p Ts.
+    ///
+    /// @warning @p T @b must be contained in @p Ts.
+    ///
+    /// @tparam T Searched type.
+    /// @tparam Ts Types containing @p T.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-10-25)
+    ///
+    template <typename T, typename... Ts>
+    struct index;
+
+    /// @copydoc index
+    template <typename T, typename... Ts>
+    struct index<T, T, Ts...> : std::integral_constant<std::size_t, 0> {
+    };
+
+    /// @copydoc index
+    template <typename T, typename U, typename... Ts>
+    struct index<T, U, Ts...> : std::integral_constant<std::size_t, 1 + index<T, Ts...>::value> {
+    };
+
+    ///
+    /// @brief Helper for right_outer_join<...>::type.
+    ///
+    /// @tparam T Searched type.
+    /// @tparam Ts Types containing @p T.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-10-29)
+    ///
+    template <typename T, typename... Ts>
+    constexpr inline std::size_t index_v = index<T, Ts...>::value;
+
+} // namespace util::meta
+
+#endif /* !UTIL_META_CONTAINS_HPP_ */

--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -535,6 +535,10 @@ struct Life {
         return value;
     }
     int value;
+
+    Life(int v) : value(v)
+    {
+    }
 };
 
 TEST(Condition, MemberToConst)

--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -4,6 +4,7 @@
 #include "ecstasy/storages/MapStorage.hpp"
 
 #include "ecstasy/query/Select.hpp"
+#include "ecstasy/query/conditions/Condition.hpp"
 #include "ecstasy/query/modifiers/And.hpp"
 #include "ecstasy/query/modifiers/Maybe.hpp"
 #include "ecstasy/query/modifiers/Not.hpp"
@@ -516,4 +517,35 @@ TEST(Query, XorVariadic)
 
     /// Xor of three inputs return true if an odd number of its input are true
     GTEST_ASSERT_EQ(query.getMask(), util::BitSet("11011100001101"));
+}
+
+/// Constant - Constant
+/// Constant - Value Member
+/// Constant - Member function
+/// Value Member - Constant
+/// Value Member - Value Member
+/// Value Member - Member function
+/// Member function - Constant
+/// Member function - Value Member
+/// Member function - Member function
+
+struct Life {
+    int getValue() const
+    {
+        return value;
+    }
+    int value;
+};
+
+TEST(Condition, MemberToConst)
+{
+    Life life{42};
+    Life death{-42};
+
+    auto memberCondition = ecstasy::query::Condition<&Life::value, 0, std::less<>>();
+    auto methodCondition = ecstasy::query::Condition<&Life::getValue, 0, std::less<>>();
+
+    GTEST_ASSERT_FALSE(memberCondition(life));
+    GTEST_ASSERT_FALSE(methodCondition(life));
+    GTEST_ASSERT_TRUE(memberCondition(death));
 }

--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -542,10 +542,24 @@ TEST(Condition, MemberToConst)
     Life life{42};
     Life death{-42};
 
-    auto memberCondition = ecstasy::query::Condition<&Life::value, 0, std::less<>>();
-    auto methodCondition = ecstasy::query::Condition<&Life::getValue, 0, std::less<>>();
+    using memberCondition = ecstasy::query::Condition<&Life::value, 0, std::less<>>;
+    using methodCondition = ecstasy::query::Condition<&Life::getValue, 0, std::less<>>;
 
-    GTEST_ASSERT_FALSE(memberCondition(life));
-    GTEST_ASSERT_FALSE(methodCondition(life));
-    GTEST_ASSERT_TRUE(memberCondition(death));
+    GTEST_ASSERT_FALSE(memberCondition::test(life));
+    GTEST_ASSERT_FALSE(methodCondition::test(life));
+    GTEST_ASSERT_TRUE(memberCondition::test(death));
+}
+
+TEST(QueryImplementation, Conditional)
+{
+    ecstasy::MapStorage<Life> lifes;
+
+    for (int i = 0; i < 13; i++)
+        lifes.emplace(i, (i % 2 == 0) ? 42 : -42);
+
+    auto query = ecstasy::query::QueryImplementation<util::meta::Traits<decltype(lifes)>,
+        util::meta::Traits<ecstasy::query::Condition<&Life::value, 0, std::less<>>>>(lifes);
+
+    for (auto [life] : query)
+        GTEST_ASSERT_TRUE(life.value < 0);
 }

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -549,3 +549,19 @@ TEST(Registry, withoutEntities)
 
     GTEST_ASSERT_FALSE(registry.hasResource<ecstasy::Entities>());
 }
+
+struct Life {
+    int value;
+};
+
+TEST(Registry, ConditionnalQuery)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 42 : -42).build();
+
+    for (auto [life] : registry.select<Life>().where<ecstasy::query::Condition<&Life::value, 0, std::less<>>>()) {
+        GTEST_ASSERT_TRUE(life.value < 0);
+    }
+}

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <math.h>
+#include "ecstasy/query/conditions/include.hpp"
 #include "ecstasy/registry/Registry.hpp"
 #include "ecstasy/registry/modifiers/Maybe.hpp"
 #include "ecstasy/registry/modifiers/Not.hpp"
@@ -671,6 +672,129 @@ TEST(Registry, ConditionnalQueryGetterConst)
     size_t i = 0;
     for (auto [life] : registry.select<Life>().where<ecstasy::query::Condition<&Life::getValue, 0, std::less<>>>()) {
         GTEST_ASSERT_TRUE(life.value < 0);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 6);
+}
+
+TEST(Registry, ConditionnalQueryGetterMember)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 42 : -42).with<Shield>((i % 3 == 0) ? -100 : 40).build();
+
+    size_t i = 0;
+    for (auto [life, shield] : registry.select<Life, Shield>()
+                                   .where<ecstasy::query::Condition<&Life::getValue, &Shield::value, std::less<>>>()) {
+        GTEST_ASSERT_TRUE(life.value < shield.value);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 4);
+}
+
+TEST(Registry, ConditionnalQueryGetterGetter)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 42 : -42).with<Shield>((i % 3 == 0) ? -100 : 40).build();
+
+    size_t i = 0;
+    for (auto [life, shield] :
+        registry.select<Life, Shield>()
+            .where<ecstasy::query::Condition<&Life::getValue, &Shield::getValue, std::less<>>>()) {
+        GTEST_ASSERT_TRUE(life.value < shield.value);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 4);
+}
+
+TEST(Registry, Less)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : -42).build();
+
+    size_t i = 0;
+    for (auto [life] : registry.select<Life>().where<ecstasy::Less<&Life::value, 0>>()) {
+        GTEST_ASSERT_TRUE(life.value < 0);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 6);
+}
+
+TEST(Registry, LessEqual)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : -42).build();
+
+    size_t i = 0;
+    for (auto [life] : registry.select<Life>().where<ecstasy::LessEqual<&Life::value, 0>>()) {
+        GTEST_ASSERT_TRUE(life.value <= 0);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 13);
+}
+
+TEST(Registry, Greater)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : 42).build();
+
+    size_t i = 0;
+    for (auto [life] : registry.select<Life>().where<ecstasy::Greater<&Life::value, 0>>()) {
+        GTEST_ASSERT_TRUE(life.value > 0);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 6);
+}
+
+TEST(Registry, GreaterEqual)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : 42).build();
+
+    size_t i = 0;
+    for (auto [life] : registry.select<Life>().where<ecstasy::GreaterEqual<&Life::value, 0>>()) {
+        GTEST_ASSERT_TRUE(life.value >= 0);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 13);
+}
+
+TEST(Registry, EqualTo)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : 42).build();
+
+    size_t i = 0;
+    for (auto [life] : registry.select<Life>().where<ecstasy::EqualTo<&Life::value, 0>>()) {
+        GTEST_ASSERT_TRUE(life.value == 0);
+        ++i;
+    }
+    GTEST_ASSERT_EQ(i, 7);
+}
+
+TEST(Registry, NotEqualTo)
+{
+    ecstasy::Registry registry;
+
+    for (int i = 0; i < 13; i++)
+        registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : 42).build();
+
+    size_t i = 0;
+    for (auto [life] : registry.select<Life>().where<ecstasy::NotEqualTo<&Life::value, 0>>()) {
+        GTEST_ASSERT_TRUE(life.value != 0);
         ++i;
     }
     GTEST_ASSERT_EQ(i, 6);

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -557,6 +557,9 @@ struct Life {
     {
         return value;
     }
+    Life(int v) : value(v)
+    {
+    }
 };
 
 struct Shield {
@@ -564,6 +567,9 @@ struct Shield {
     int getValue() const
     {
         return value;
+    }
+    Shield(int v) : value(v)
+    {
     }
 };
 

--- a/tests/util/meta/CMakeLists.txt
+++ b/tests/util/meta/CMakeLists.txt
@@ -3,7 +3,9 @@ set(SRCROOT ${SRCROOT}/meta)
 set(SRC
     ${SRC}
     ${SRCROOT}/tests_add_optional.cpp
+    ${SRCROOT}/tests_apply.cpp
     ${SRCROOT}/tests_contains.cpp
+    ${SRCROOT}/tests_filter.cpp
     ${SRCROOT}/tests_outer_join.cpp
     ${SRCROOT}/tests_type_set_eq.cpp
     PARENT_SCOPE

--- a/tests/util/meta/tests_apply.cpp
+++ b/tests/util/meta/tests_apply.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "util/meta/apply.hpp"
+
+TEST(apply, identity)
+{
+    using got = util::meta::apply_t<std::type_identity_t, int, float, double, std::string>;
+    using expected = util::meta::Traits<int, float, double, std::string>;
+    bool res = std::is_same_v<got, expected>;
+
+    GTEST_ASSERT_TRUE(res);
+}
+
+TEST(apply, remove_reference)
+{
+    using got = util::meta::apply_t<std::remove_reference_t, int &, float, double &, std::string>;
+    using expected = util::meta::Traits<int, float, double, std::string>;
+    bool res = std::is_same_v<got, expected>;
+
+    GTEST_ASSERT_TRUE(res);
+}

--- a/tests/util/meta/tests_filter.cpp
+++ b/tests/util/meta/tests_filter.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "util/meta/filter.hpp"
+
+TEST(filter, arithmetic)
+{
+    using got = util::meta::filter_t<std::is_arithmetic, int, float, double, std::string>;
+    using expected = util::meta::Traits<int, float, double>;
+    bool res = std::is_same_v<got, expected>;
+
+    GTEST_ASSERT_TRUE(res);
+}
+
+TEST(filter, is_floating)
+{
+    using got = util::meta::filter_t<std::is_floating_point, int, float, double, std::string>;
+    using expected = util::meta::Traits<float, double>;
+    bool res = std::is_same_v<got, expected>;
+
+    GTEST_ASSERT_TRUE(res);
+}


### PR DESCRIPTION
# Description

### Query Conditions
Introduce new query runtime conditions allowing to prefilter some entities using comparison operators.

Available buitin conditions:
- Less
- LessEqual
- Greater
- GreaterEqual
- EqualTo
- NotEqualTo

Usage:
```cpp
ecstasy::Registry registry;

for (int i = 0; i < 13; i++)
    registry.entityBuilder().with<Life>((i % 2 == 0) ? 0 : -42).build();

for (auto [life] : registry.select<Life>().where<ecstasy::Less<&Life::value, 0>>()) {
/// Only entities with life lower than 0.
}
```

### apply and filter meta utilities

New **apply** structure to apply a template type on a parameter pack types.
New **filter** meta structure to filter a parameter pack using a given templated filter.

Close #97

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New tests have been written for each feature.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
