### PR TITLE
Set Queryable constraint on Query class

### DIFF
--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -89,6 +89,47 @@ TEST(Query, where)
     GTEST_ASSERT_EQ(size8.y, 16);
 }
 
+TEST(Query, IteratorPosition)
+{
+    ecstasy::MapStorage<Position> positions;
+    ecstasy::MapStorage<Size> sizes;
+    ecstasy::Entities entities;
+    for (int i = 0; i < 10; i++) {
+        entities.create();
+        if (i % 2 == 0)
+            positions.emplace(i, i * 2, i * 10);
+        if (i % 3 == 0 || i == 8)
+            sizes.emplace(i, i * 10, i * 2);
+    }
+
+    auto query3 = ecstasy::query::Query(entities, positions, sizes);
+    GTEST_ASSERT_EQ(query3.getMask(), util::BitSet("1101000001"));
+
+    auto it = query3.begin();
+    /// 0
+    GTEST_ASSERT_EQ(it.getPosition(), 0);
+    auto [e, pos, size] = *it;
+    GTEST_ASSERT_EQ(pos.y, 0);
+    GTEST_ASSERT_EQ(size.y, 0);
+
+    /// 6
+    ++it;
+    GTEST_ASSERT_EQ(it.getPosition(), 6);
+    auto [e2, pos6, size6] = *it;
+    auto [e2_, pos6_, size6_] = query3.getQueryData(it.getPosition());
+    GTEST_ASSERT_EQ(pos6.y, 60);
+    GTEST_ASSERT_EQ(size6.y, 12);
+    GTEST_ASSERT_EQ(pos6.y, pos6_.y);
+    GTEST_ASSERT_EQ(size6.y, size6_.y);
+
+    /// 8
+    ++it;
+    GTEST_ASSERT_EQ(it.getPosition(), 8);
+    auto [e3, pos8, size8] = *it;
+    GTEST_ASSERT_EQ(pos8.y, 80);
+    GTEST_ASSERT_EQ(size8.y, 16);
+}
+
 TEST(Select, omitStorages)
 {
     ecstasy::MapStorage<Position> positions;


### PR DESCRIPTION
# Description

Introduce QueryImplementation::QueryData typename and QueryImplementaton::getQueryData(size_t index) to satisfy the Queryable concept constraint.

Also introduced a new method getPosition for the query iterators.

Close #102

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
