### PR TITLE
Support brace initializer in entity builders

### DIFF
--- a/src/ecstasy/registry/Registry.hpp
+++ b/src/ecstasy/registry/Registry.hpp
@@ -198,6 +198,32 @@ namespace ecstasy
             }
 
             ///
+            /// @brief Add a component to the builder target entity.
+            ///
+            /// @tparam C Component type.
+            ///
+            /// @param[in] list Initializer list to forward to the component constructor.
+            ///
+            /// @return EntityBuilder& @b this.
+            ///
+            /// @throw std::logic_error If the builder was already consumed or if the entity already has the
+            /// component.
+            ///
+            /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+            /// @since 1.0.0 (2023-01-31)
+            ///
+            template <typename C>
+            requires requires()
+            {
+                typename C::value_type;
+            }
+            EntityBuilder &with(std::initializer_list<typename C::value_type> list)
+            {
+                _builder.with(_registry.getStorageSafe<C>(), list);
+                return *this;
+            }
+
+            ///
             /// @brief Finalize the entity, making it alive.
             ///
             /// @return Entity Newly created entity.

--- a/src/ecstasy/resources/entity/Entities.hpp
+++ b/src/ecstasy/resources/entity/Entities.hpp
@@ -73,6 +73,30 @@ namespace ecstasy
             }
 
             ///
+            /// @brief Add a component to the builder target entity.
+            ///
+            /// @tparam S Component storage type.
+            ///
+            /// @param[in] storage Component storage.
+            /// @param[in] list Initializer list to forward to the component constructor.
+            ///
+            /// @return Builder& @b this.
+            ///
+            /// @throw std::logic_error If the builder was already consumed or if the entity already has the
+            /// component.
+            ///
+            /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+            /// @since 1.0.0 (2023-01-31)
+            ///
+            template <IsContainerStorage S>
+            Builder &with(S &storage, std::initializer_list<typename S::Component::value_type> list)
+            {
+                assertNotBuilt();
+                _entity.add(storage, list);
+                return *this;
+            }
+
+            ///
             /// @brief Finalize the entity, making it alive.
             ///
             /// @return Entity Newly created entity.

--- a/src/ecstasy/storages/StorageConcepts.hpp
+++ b/src/ecstasy/storages/StorageConcepts.hpp
@@ -43,5 +43,12 @@ namespace ecstasy
     {
         typename S::Component;
     };
+
+    template <typename S>
+    concept IsContainerStorage = requires()
+    {
+        requires IsStorage<S>;
+        typename S::Component::value_type;
+    };
 } // namespace ecstasy
 #endif /* !ECSTASY_STORAGE_STORAGECONCEPTS_HPP_ */

--- a/tests/entity/tests_Entities.cpp
+++ b/tests/entity/tests_Entities.cpp
@@ -61,11 +61,12 @@ TEST(Entities, builder)
     ecstasy::MapStorage<Velocity> velocities;
     ecstasy::MapStorage<Size> sizes;
     ecstasy::MapStorage<Vector2i> vectors;
+    ecstasy::MapStorage<std::vector<int>> intVectors;
     ecstasy::Entities entities;
 
     /// Build the entity
     ecstasy::Entities::Builder builder = entities.builder();
-    builder.with(positions, 1, 2).with(velocities, 3, 4).with(sizes, 4, 5);
+    builder.with(positions, 1, 2).with(velocities, 3, 4).with(sizes, 4, 5).with(intVectors, {1, 2, 3, 4, 5, 6});
     EXPECT_THROW(builder.with(positions, 42, 84), std::logic_error);
     ecstasy::Entity e = builder.build();
 
@@ -77,6 +78,8 @@ TEST(Entities, builder)
     EXPECT_TRUE(e.has(positions));
     EXPECT_TRUE(e.has(velocities));
     EXPECT_TRUE(e.has(sizes));
+    EXPECT_TRUE(e.has(intVectors));
+    EXPECT_EQ(e.get(intVectors).size(), 6);
     EXPECT_FALSE(e.has(vectors));
 }
 

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -246,7 +246,7 @@ TEST(Registry, EntityBuilder)
 
     /// Build the entity
     ecstasy::Registry::EntityBuilder builder = registry.entityBuilder();
-    builder.with<Position>(1, 2).with<Velocity>(3, 4).with<Size>(4, 5);
+    builder.with<Position>(1, 2).with<Velocity>(3, 4).with<Size>(4, 5).with<std::vector<int>>({1, 2, 3, 4, 5, 6});
     EXPECT_THROW(builder.with<Position>(42, 84), std::logic_error);
     ecstasy::RegistryEntity e(builder.build(), registry);
 
@@ -258,6 +258,8 @@ TEST(Registry, EntityBuilder)
     EXPECT_TRUE(e.has<Position>());
     EXPECT_TRUE(e.has<Velocity>());
     EXPECT_TRUE(e.has<Size>());
+    EXPECT_TRUE(e.has<std::vector<int>>());
+    EXPECT_EQ(e.get<std::vector<int>>().size(), 6);
     EXPECT_FALSE(e.has<Vector2i>());
 }
 


### PR DESCRIPTION
# Description

Allow to use brace initializer when adding new components to entity (using entity builder):

```cpp
registry.entityBuilder().with<std::vector<int>>({1, 2, 3, 4, 5, 6});
```

Close #105

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Current entity builder tests have been updated to use a component with brace initializer.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
