### PR TITLE
Introduce ActionListeners map

### DIFF
--- a/src/ecstasy/integrations/user_action/ActionListener.hpp
+++ b/src/ecstasy/integrations/user_action/ActionListener.hpp
@@ -14,6 +14,7 @@
 
 #include "ecstasy/integrations/event/listeners/EventListeners.hpp"
 #include "ecstasy/integrations/user_action/UserProfile.hpp"
+#include <unordered_map>
 
 namespace ecstasy::integration::user_action
 {
@@ -71,6 +72,16 @@ namespace ecstasy::integration::user_action
         {
         }
     };
+
+    ///
+    /// @brief Action listeners map. Used to listen to more than one Action on a single entity.
+    ///
+    /// @note Doesn't handle @ref Action::All .
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2023-01-31)
+    ///
+    using ActionListeners = std::unordered_map<Action::Id, ActionListener::Listener>;
 } // namespace ecstasy::integration::user_action
 
 #endif /* !ECSTASY_INTEGRATIONS_USER_ACTION_ACTIONLISTENER_HPP_ */

--- a/tests/integration/user_action/tests_Users.cpp
+++ b/tests/integration/user_action/tests_Users.cpp
@@ -154,35 +154,28 @@ TEST(Users, handleEvent)
             },
             0)
         .build();
-    /// Match action 1 (keyboard)
     registry.entityBuilder()
-        .with<user_action::ActionListener>(
-            [&values](ecstasy::Registry &r, ecstasy::Entity e, user_action::Action a) {
-                (void)r;
-                (void)e;
-                values[2] += a.value + 1.f;
-            },
-            1)
-        .build();
-    /// Match action 2 (gamepad button)
-    registry.entityBuilder()
-        .with<user_action::ActionListener>(
-            [&values](ecstasy::Registry &r, ecstasy::Entity e, user_action::Action a) {
-                (void)r;
-                (void)e;
-                values[3] += a.value + 1.f;
-            },
-            2)
-        .build();
-    /// Match action 3 (gamepad axis)
-    registry.entityBuilder()
-        .with<user_action::ActionListener>(
-            [&values](ecstasy::Registry &r, ecstasy::Entity e, user_action::Action a) {
-                (void)r;
-                (void)e;
-                values[4] += a.value + 1.f;
-            },
-            3)
+        .with<user_action::ActionListeners>({/// Match action 1 (keyboard)
+            {1,
+                [&values](ecstasy::Registry &r, ecstasy::Entity e, user_action::Action a) {
+                    (void)r;
+                    (void)e;
+                    values[2] += a.value + 1.f;
+                }},
+            /// Match action 2 (gamepad button)
+            {2,
+                [&values](ecstasy::Registry &r, ecstasy::Entity e, user_action::Action a) {
+                    (void)r;
+                    (void)e;
+                    values[3] += a.value + 1.f;
+                }},
+            /// Match action 3 (gamepad axis)
+            {3,
+                [&values](ecstasy::Registry &r, ecstasy::Entity e, user_action::Action a) {
+                    (void)r;
+                    (void)e;
+                    values[4] += a.value + 1.f;
+                }}})
         .build();
 
     /// Event not handled by the Users::handleEvent


### PR DESCRIPTION
# Description

Introduce a new ActionListeners component type to allow a single entity to listen to multiple action id.
It is simply an alias for a map<ActionId, ActionListener>.

Close #104

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing action listener tests have been updated to use both single ActionListener component and new ActionListeners one.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
