### PR TITLE
Feature/68 stack modifier allocator

### DIFF
--- a/src/ecstasy/integrations/event/EventsManager.cpp
+++ b/src/ecstasy/integrations/event/EventsManager.cpp
@@ -32,11 +32,9 @@ namespace ecstasy::integration::event
     template <typename E>
     static void callListeners(Registry &registry, const E &event)
     {
-        ecstasy::ModifiersAllocator allocator;
-
         for (auto [entity, listener, listeners] :
             registry.select<Entities, Maybe<EventListener<E>>, Maybe<EventListeners<E>>>()
-                .template where<Or<EventListener<E>, EventListeners<E>>>(allocator)) {
+                .template where<Or<EventListener<E>, EventListeners<E>>>()) {
             if (listener)
                 listener.value()(registry, entity, event);
             if (listeners)
@@ -46,15 +44,12 @@ namespace ecstasy::integration::event
 
     static void callKeyListeners(Registry &registry, const KeyEvent &event)
     {
-        ecstasy::ModifiersAllocator allocator;
-
         for (auto [entity, listener, listeners, sequence, combination] :
             registry
                 .select<Entities, Maybe<EventListener<KeyEvent>>, Maybe<EventListeners<KeyEvent>>,
                     Maybe<KeySequenceListener>, Maybe<KeyCombinationListener>>()
-                .where<
-                    Or<EventListener<KeyEvent>, EventListeners<KeyEvent>, KeySequenceListener, KeyCombinationListener>>(
-                    allocator)) {
+                .where<Or<EventListener<KeyEvent>, EventListeners<KeyEvent>, KeySequenceListener,
+                    KeyCombinationListener>>()) {
             if (listener)
                 listener.value()(registry, entity, event);
             if (listeners)

--- a/src/ecstasy/integrations/user_action/Users.cpp
+++ b/src/ecstasy/integrations/user_action/Users.cpp
@@ -62,11 +62,10 @@ namespace ecstasy::integration::user_action
     {
         if (registry.hasResource<PendingActions>())
             registry.getResource<PendingActions>().get().push(action);
-        ecstasy::ModifiersAllocator allocator;
 
         for (auto [entity, maybeListener, maybeListeners] :
             registry.select<Entities, Maybe<ActionListener>, Maybe<ActionListeners>>()
-                .where<Entities, Or<ActionListener, ActionListeners>>(allocator)) {
+                .where<Entities, Or<ActionListener, ActionListeners>>()) {
             if (maybeListener) {
                 if (maybeListener->get().actionId == Action::All || maybeListener->get().actionId == action.id)
                     maybeListener->get().listener(registry, entity, action);

--- a/src/ecstasy/registry/concepts/QueryableAllocatorSize.hpp
+++ b/src/ecstasy/registry/concepts/QueryableAllocatorSize.hpp
@@ -1,0 +1,96 @@
+///
+/// @file QueryableAllocatorSize.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2023-11-08
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef ECSTASY_REGISTRY_CONCEPTS_QUERYABLEALLOCATORSIZE_HPP_
+#define ECSTASY_REGISTRY_CONCEPTS_QUERYABLEALLOCATORSIZE_HPP_
+
+#include "ecstasy/query/concepts/Modifier.hpp"
+#include "ecstasy/query/concepts/Queryable.hpp"
+#include "ecstasy/registry/concepts/RegistryModifier.hpp"
+
+namespace ecstasy
+{
+    ///
+    /// @brief Get the allocator required size for a list of queryables. It is equal to the sum of the modifiers memory
+    /// size (if any). Returns 0 if there is no modifier.
+    ///
+    /// @tparam Qs Evaluated types.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2023-11-08)
+    ///
+    template <typename... Qs>
+    struct queryables_allocator_size : public std::integral_constant<size_t, 0> {
+    };
+
+    ///
+    /// @brief Get the allocator required size for this queryable. It is equal to the modifier memory size (if any).
+    /// Returns 0 if there is no modifier.
+    ///
+    /// @tparam Q Evaluated type.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2023-11-08)
+    ///
+    template <typename Q>
+    struct queryable_allocator_size : public std::integral_constant<size_t, 0> {
+    };
+
+    /// @copydoc queryable_allocator_size
+    template <RegistryModifier M>
+    struct queryable_allocator_size<M> : public queryable_allocator_size<typename M::Modifier> {
+    };
+
+    /// @copydoc queryable_allocator_size
+    template <query::Modifier M>
+    struct queryable_allocator_size<M>
+        : public std::integral_constant<size_t, sizeof(M) + queryable_allocator_size<typename M::Operands>::value> {
+    };
+
+    /// @copydoc queryable_allocator_size
+    template <typename Q, typename... Qs>
+    struct queryable_allocator_size<std::tuple<Q, Qs...>>
+        : public std::integral_constant<size_t, queryables_allocator_size<Q, Qs...>::value> {
+    };
+
+    ///
+    /// @brief Helper for queryable_allocator_size<Q>::value.
+    ///
+    /// @tparam Q Evaluated type.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2023-11-08)
+    ///
+    template <typename Q>
+    size_t constexpr queryable_allocator_size_v = queryable_allocator_size<Q>::value;
+
+    /// @copydoc queryables_allocator_size
+    template <typename Q, typename... Qs>
+    struct queryables_allocator_size<Q, Qs...>
+        : public std::integral_constant<size_t,
+              queryable_allocator_size_v<Q> + queryables_allocator_size<Qs...>::value> {
+    };
+
+    ///
+    /// @brief Helper for queryables_allocator_size<Q, Qs...>::value.
+    ///
+    /// @tparam Q Evaluated type.
+    /// @tparam Qs Next evaluated types.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2023-11-08)
+    ///
+    template <typename Q, typename... Qs>
+    size_t constexpr queryables_allocator_size_v = queryables_allocator_size<Q, Qs...>::value;
+
+} // namespace ecstasy
+
+#endif /* !ECSTASY_REGISTRY_CONCEPTS_QUERYABLEALLOCATORSIZE_HPP_ */

--- a/src/ecstasy/registry/concepts/RegistryModifier.hpp
+++ b/src/ecstasy/registry/concepts/RegistryModifier.hpp
@@ -1,5 +1,5 @@
 ///
-/// @file Modifiers.hpp
+/// @file RegistryModifier.hpp
 /// @author Andréas Leroux (andreas.leroux@epitech.eu)
 /// @brief
 /// @version 1.0.0

--- a/src/util/StackAllocator.hpp
+++ b/src/util/StackAllocator.hpp
@@ -1,0 +1,146 @@
+///
+/// @file StackAllocator.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief Stack Allocator
+/// @version 1.0.0
+/// @date 2023-11-08
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#ifndef UTIL_STACKALLOCATOR_HPP_
+#define UTIL_STACKALLOCATOR_HPP_
+
+#include <cstring>
+#include <memory>
+#include <new>
+#include <vector>
+
+namespace util
+{
+    /// @internal
+    /// @brief Template of a vector to manage lifetime of multiple instances inheriting the same base class.
+    /// This allocator allocate instances on the stack and therefore requires to know the exact byte size at compile
+    /// time (or expect uncatchable program segmentation fault or memory corruption).
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2022-10-24)
+    ///
+    template <size_t size, typename Base>
+    class StackAllocator {
+      public:
+        /// @brief Size in byte of the allocator memory
+        ///
+        /// @note This is an alias to the template parameter @tparam size
+        static constexpr size_t mem_size = size;
+
+        ///
+        /// @brief Default constructor.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2023-11-08)
+        ///
+        StackAllocator()
+        {
+            _cursor = 0;
+        }
+
+        ///
+        /// @brief Move constructor.
+        ///
+        /// @warning Instances must not have pointers/reference to object in @p other memory block.
+        ///
+        /// @param[in] other Existing allocator to copy.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2023-11-08)
+        ///
+        StackAllocator(StackAllocator &&other)
+        {
+            *this = std::move(other);
+        }
+
+        ///
+        /// @brief Destructor.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2023-11-08)
+        ///
+        ~StackAllocator()
+        {
+            for (auto &&object : _instances)
+                (*object).~Base();
+        }
+
+        ///
+        /// @brief Move assignment operator.
+        ///
+        /// @warning Instances must not have pointers/reference to object in @p other memory block.
+        ///
+        /// @param[in] other Existing allocator to move into @b this.
+        ///
+        /// @return StackAllocator& @b this
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2023-11-08)
+        ///
+        StackAllocator &operator=(StackAllocator &&other)
+        {
+            // Doesn't support overlap but we shouldn't have any
+            std::memcpy(_memory, other._memory, size);
+            _cursor = other._cursor;
+            for (Base *instance : other._instances)
+                _instances.push_back(reinterpret_cast<Base *>(reinterpret_cast<char *>(_memory)
+                    + (reinterpret_cast<char *>(instance) - reinterpret_cast<char *>(other._memory))));
+
+            // Clear other
+            other._cursor = 0;
+            other._instances.clear();
+            return *this;
+        }
+
+        ///
+        /// @brief Instanciate a new instance of type T with lifetime attached to @b this lifetime.
+        ///
+        /// @tparam T Type of the new object.
+        /// @tparam Args Arguments Types of the object constructor.
+        ///
+        /// @param[in] args Arguments to forward to the object constructor.
+        ///
+        /// @return T& newly created object.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2022-10-24)
+        ///
+        template <std::derived_from<Base> T, typename... Args>
+        T &instanciate(Args &&...args)
+        {
+            T *newObject = new (reinterpret_cast<void *>(&_memory[_cursor])) T(std::forward<Args>(args)...);
+
+            _instances.push_back(newObject);
+            _cursor += sizeof(T);
+            return *newObject;
+        }
+
+        ///
+        /// @brief Access the internal instances vector.
+        ///
+        /// @return const std::vector<Base *>& Read only instances vector.
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2023-11-08)
+        ///
+        constexpr const std::vector<Base *> &getInstances() const
+        {
+            return _instances;
+        }
+
+      private:
+        char _memory[size];
+
+        size_t _cursor;
+        std::vector<Base *> _instances;
+    };
+} // namespace util
+
+#endif /* !UTIL_STACKALLOCATOR_HPP_ */

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -131,10 +131,8 @@ struct Gravity : public ecstasy::ISystem {
 struct Movement : public ecstasy::ISystem {
     void run(ecstasy::Registry &registry) override final
     {
-        ecstasy::ModifiersAllocator allocator;
-
         for (auto [position, velocity] :
-            registry.select<Position, Velocity>().where<Position, Movable, Velocity, ecstasy::Not<Static>>(allocator)) {
+            registry.select<Position, Velocity>().where<Position, Movable, Velocity, ecstasy::Not<Static>>()) {
             position.v.x += velocity.v.x;
             position.v.y += velocity.v.y;
         }
@@ -318,7 +316,6 @@ TEST(Registry, functionnal)
 TEST(Registry, MaybeQuery)
 {
     ecstasy::Registry registry;
-    ecstasy::ModifiersAllocator allocator;
 
     for (int i = 0; i < 13; i++) {
         auto builder = registry.entityBuilder();
@@ -331,7 +328,7 @@ TEST(Registry, MaybeQuery)
         builder.build();
     }
 
-    auto query = registry.query<Position, Velocity, ecstasy::Maybe<Density>>(allocator);
+    auto query = registry.query<Position, Velocity, ecstasy::Maybe<Density>>();
     auto query2 = registry.query<Position, Velocity>();
     GTEST_ASSERT_EQ(query.getMask(), util::BitSet("11000101000001"));
     GTEST_ASSERT_EQ(query.getMask(), query2.getMask());
@@ -381,7 +378,6 @@ TEST(Registry, MaybeQuery)
 TEST(Registry, MaybeSelect)
 {
     ecstasy::Registry registry;
-    ecstasy::ModifiersAllocator allocator;
 
     for (int i = 0; i < 13; i++) {
         auto builder = registry.entityBuilder();
@@ -394,10 +390,9 @@ TEST(Registry, MaybeSelect)
         builder.build();
     }
 
-    auto query = registry.query<Position, Velocity, ecstasy::Maybe<Density>>(allocator);
+    auto query = registry.query<Position, Velocity, ecstasy::Maybe<Density>>();
     auto select =
-        registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>(
-            allocator);
+        registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>();
 
     GTEST_ASSERT_EQ(query.getMask(), select.getMask());
     GTEST_ASSERT_EQ(query.getMask(), util::BitSet("11000101000001"));
@@ -406,7 +401,6 @@ TEST(Registry, MaybeSelect)
 TEST(Registry, ImplicitWhere)
 {
     ecstasy::Registry registry;
-    ecstasy::ModifiersAllocator allocator;
 
     for (int i = 0; i < 13; i++) {
         auto builder = registry.entityBuilder();
@@ -417,13 +411,6 @@ TEST(Registry, ImplicitWhere)
         if (i % 4 == 0)
             builder.with<Density>(i * 4);
         builder.build();
-    }
-
-    /// Missing standard component, With allocator
-    {
-        auto explicitQuery = registry.select<Position>().where<Position, Velocity>(allocator);
-        auto implicitQuery = registry.select<Position>().where<Velocity>(allocator);
-        GTEST_ASSERT_EQ(explicitQuery.getMask(), implicitQuery.getMask());
     }
 
     /// Missing standard component, Wihtout allocator
@@ -433,21 +420,19 @@ TEST(Registry, ImplicitWhere)
         GTEST_ASSERT_EQ(explicitQuery.getMask(), implicitQuery.getMask());
     }
 
-    /// Missing modifier, With allocator (required)
+    /// Missing modifier
     {
         auto explicitQuery =
-            registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>(
-                allocator);
-        auto implicitQuery = registry.select<ecstasy::Maybe<Density>, Position>().where<Position, Velocity>(allocator);
+            registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>();
+        auto implicitQuery = registry.select<ecstasy::Maybe<Density>, Position>().where<Position, Velocity>();
         GTEST_ASSERT_EQ(explicitQuery.getMask(), implicitQuery.getMask());
     }
 
-    /// Missing modifier and component, With allocator (required)
+    /// Missing modifier and component
     {
         auto explicitQuery =
-            registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>(
-                allocator);
-        auto implicitQuery = registry.select<Position, ecstasy::Maybe<Density>>().where<Velocity>(allocator);
+            registry.select<Position, ecstasy::Maybe<Density>>().where<Position, Velocity, ecstasy::Maybe<Density>>();
+        auto implicitQuery = registry.select<Position, ecstasy::Maybe<Density>>().where<Velocity>();
         GTEST_ASSERT_EQ(explicitQuery.getMask(), implicitQuery.getMask());
     }
 }
@@ -455,7 +440,6 @@ TEST(Registry, ImplicitWhere)
 TEST(Registry, OrSelect)
 {
     ecstasy::Registry registry;
-    ecstasy::ModifiersAllocator allocator;
 
     for (int i = 0; i < 13; i++) {
         auto builder = registry.entityBuilder();
@@ -469,8 +453,8 @@ TEST(Registry, OrSelect)
     }
 
     // clang-format off
-    auto query = registry.select<Position>().where<ecstasy::Or<Velocity, Density>>(allocator);
-    auto query2 = registry.select<Position, ecstasy::Maybe<Velocity>, ecstasy::Maybe<Density>>().where<ecstasy::Or<Velocity, Density>>(allocator);
+    auto query = registry.select<Position>().where<ecstasy::Or<Velocity, Density>>();
+    auto query2 = registry.select<Position, ecstasy::Maybe<Velocity>, ecstasy::Maybe<Density>>().where<ecstasy::Or<Velocity, Density>>();
     auto posAndVel = registry.query<Position, Velocity>();
     auto posAndDensity = registry.query<Position, Density>();
 

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SRCROOT ${SRCROOT}/util)
 
 set(SRC
     ${SRCROOT}/tests_BitSet.cpp
+    ${SRCROOT}/tests_StackAllocator.cpp
 )
 
 add_subdirectory(meta)

--- a/tests/util/tests_StackAllocator.cpp
+++ b/tests/util/tests_StackAllocator.cpp
@@ -1,0 +1,109 @@
+///
+/// @file test_StackAllocator.cpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief @ref StackAllocator tests
+/// @version 1.0.0
+/// @date 2023-11-08
+///
+/// @copyright Copyright (c) ECSTASY 2022
+///
+///
+
+#include <gtest/gtest.h>
+
+#include "util/StackAllocator.hpp"
+
+class Base {
+  public:
+    Base(int &reference) : _reference(reference)
+    {
+        _reference++;
+    }
+
+    ~Base()
+    {
+        _reference--;
+    }
+
+    virtual int getId() const
+    {
+        return 0;
+    }
+
+  private:
+    std::reference_wrapper<int> _reference;
+};
+
+class A : public Base {
+  public:
+    A(int &reference) : Base(reference)
+    {
+    }
+    virtual int getId() const override
+    {
+        return 1;
+    }
+
+  private:
+    char _reserved[15];
+};
+
+class B : public Base {
+  public:
+    B(int &reference) : Base(reference)
+    {
+    }
+    virtual int getId() const override
+    {
+        return 2;
+    }
+
+  private:
+    char _reserved[2];
+};
+
+class C : public Base {
+  public:
+    C(int &reference) : Base(reference)
+    {
+    }
+
+  private:
+    char _reserved[51];
+};
+
+TEST(StackAllocator, init)
+{
+    // Testing with 0 as size makes the compilation fails as expected:
+    // util::StackAllocator<0, Base> allocator;
+    constexpr size_t size = sizeof(A) + sizeof(B) + sizeof(C);
+    int ref_counter = 0;
+
+    {
+        util::StackAllocator<size, Base> allocator;
+        A &a = allocator.instanciate<A>(ref_counter);
+        B &b = allocator.instanciate<B>(ref_counter);
+        C &c = allocator.instanciate<C>(ref_counter);
+
+        GTEST_ASSERT_EQ(ref_counter, 3);
+        GTEST_ASSERT_EQ(c.getId(), 0);
+        GTEST_ASSERT_EQ(a.getId(), 1);
+        GTEST_ASSERT_EQ(b.getId(), 2);
+
+        util::StackAllocator<size, Base> movedAllocator(std::move(allocator));
+
+        GTEST_ASSERT_EQ(ref_counter, 3);
+        GTEST_ASSERT_TRUE(allocator.getInstances().empty());
+        // Fetch the new references (old ones were invalidate and testing them would probably cause a segmentation
+        // fault)
+        a = dynamic_cast<A &>(*movedAllocator.getInstances()[0]);
+        b = dynamic_cast<B &>(*movedAllocator.getInstances()[1]);
+        c = dynamic_cast<C &>(*movedAllocator.getInstances()[2]);
+
+        GTEST_ASSERT_EQ(c.getId(), 0);
+        GTEST_ASSERT_EQ(a.getId(), 1);
+        GTEST_ASSERT_EQ(b.getId(), 2);
+    }
+    // Ensure destructor is called only once
+    GTEST_ASSERT_EQ(ref_counter, 0);
+}


### PR DESCRIPTION
# Description

### StackAllocator

Introduce a new StackAllocator. This is not really an allocator, more likely a reserved memory block. The idea is to reserve a specific memory size to allocate objects in this memory block. It supports move operations by copying the memory block.

```cpp
constexpr size_t size = sizeof(A) + sizeof(B) + sizeof(C);
util::StackAllocator<size, Base> allocator;

A &a = allocator.instanciate<A>(ref_counter);
B &b = allocator.instanciate<B>(ref_counter);
C &c = allocator.instanciate<C>(ref_counter);
```

### queryables_allocator_size

Introduce new queryables_allocator_size(_t) meta type to compute the required size in the allocator for a given queryable, or list of queryable.

### Templated all use of allocator in registry

If no allocator is given and one is required (ie queryable allocator size is not null) the stack allocator is used. However if the user wants to use a custom allocator it is still possible since all allocator are templated

Close #68 (Finally)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing unit tests have been updated.
New unit tests for 
- StackAllocator
- queryables_allocator_size
- stackAllocator

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
