### PR TITLE
Fix event integration Keyboard::Key enum starting at 0 instead of -1

### DIFF
--- a/src/ecstasy/integrations/event/inputs/Gamepad.hpp
+++ b/src/ecstasy/integrations/event/inputs/Gamepad.hpp
@@ -31,15 +31,16 @@ namespace ecstasy::integration::event
       public:
         // LCOV_EXCL_START
 
-        SERIALIZABLE_ENUM(Button, Unknown, FaceUp, FaceRight, FaceDown, FaceLeft, BumperLeft, BumperRight, MiddleLeft,
-            Middle, MiddleRight, ThumbLeft, ThumbRight, Count)
-        SERIALIZABLE_ENUM(Axis, Unknown, LeftX, LeftY, RightX, RightY, TriggerLeft, TriggerRight, DPadX, DPadY, Count)
+        SERIALIZABLE_ENUM(Button, -1, Unknown, FaceUp, FaceRight, FaceDown, FaceLeft, BumperLeft, BumperRight,
+            MiddleLeft, Middle, MiddleRight, ThumbLeft, ThumbRight, Count)
+        SERIALIZABLE_ENUM(
+            Axis, -1, Unknown, LeftX, LeftY, RightX, RightY, TriggerLeft, TriggerRight, DPadX, DPadY, Count)
 
         // LCOV_EXCL_STOP
 #ifdef _DOXYGEN_
         /// @brief Gamepad buttons
         enum class Button {
-            Unknown, ///< Unhandled button
+            Unknown = -1, ///< Unhandled button
             /// Face Buttons
             FaceUp,    ///< Face button up (i.e. PS: Triangle, Xbox: Y)
             FaceRight, ///< Face button right (i.e. PS: Square, Xbox: X)
@@ -61,7 +62,7 @@ namespace ecstasy::integration::event
 
         /// @brief Gamepad axis, associated value must be in range [-1, 1]
         enum class Axis {
-            Unknown,      ///< Unhandled axis
+            Unknown = -1, ///< Unhandled axis
             LeftX,        ///< Left joystick X axis (default: 0)
             LeftY,        ///< Left joystick Y axis (default: 0)
             RightX,       ///< Right joystick X axis (default: 0)

--- a/src/ecstasy/integrations/event/inputs/Keyboard.hpp
+++ b/src/ecstasy/integrations/event/inputs/Keyboard.hpp
@@ -31,8 +31,8 @@ namespace ecstasy::integration::event
       public:
         // LCOV_EXCL_START
 
-        SERIALIZABLE_ENUM(Key, Unknown, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
-            Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9, Escape, LControl, LShift, LAlt, LSystem,
+        SERIALIZABLE_ENUM(Key, -1, Unknown, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y,
+            Z, Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9, Escape, LControl, LShift, LAlt, LSystem,
             RControl, RShift, RAlt, RSystem, Menu, LBracket, RBracket, Semicolon, Comma, Period, Quote, Slash,
             Backslash, Tilde, Equal, Hyphen, Space, Enter, Backspace, Tab, PageUp, PageDown, End, Home, Insert, Delete,
             Add, Subtract, Multiply, Divide, Left, Right, Up, Down, Numpad0, Numpad1, Numpad2, Numpad3, Numpad4,
@@ -43,108 +43,108 @@ namespace ecstasy::integration::event
 #ifdef _DOXYGEN
         /// @brief Keyboard keys.
         enum class Key {
-            Unknown,   ///< Unhandled key
-            A,         ///< The A key
-            B,         ///< The B key
-            C,         ///< The C key
-            D,         ///< The D key
-            E,         ///< The E key
-            F,         ///< The F key
-            G,         ///< The G key
-            H,         ///< The H key
-            I,         ///< The I key
-            J,         ///< The J key
-            K,         ///< The K key
-            L,         ///< The L key
-            M,         ///< The M key
-            N,         ///< The N key
-            O,         ///< The O key
-            P,         ///< The P key
-            Q,         ///< The Q key
-            R,         ///< The R key
-            S,         ///< The S key
-            T,         ///< The T key
-            U,         ///< The U key
-            V,         ///< The V key
-            W,         ///< The W key
-            X,         ///< The X key
-            Y,         ///< The Y key
-            Z,         ///< The Z key
-            Num0,      ///< The 0 key
-            Num1,      ///< The 1 key
-            Num2,      ///< The 2 key
-            Num3,      ///< The 3 key
-            Num4,      ///< The 4 key
-            Num5,      ///< The 5 key
-            Num6,      ///< The 6 key
-            Num7,      ///< The 7 key
-            Num8,      ///< The 8 key
-            Num9,      ///< The 9 key
-            Escape,    ///< The Escape key
-            LControl,  ///< The left Control key
-            LShift,    ///< The left Shift key
-            LAlt,      ///< The left Alt key
-            LSystem,   ///< The left OS specific key: window (Windows and Linux), apple (MacOS X), ...
-            RControl,  ///< The right Control key
-            RShift,    ///< The right Shift key
-            RAlt,      ///< The right Alt key
-            RSystem,   ///< The right OS specific key: window (Windows and Linux), apple (MacOS X), ...
-            Menu,      ///< The Menu key
-            LBracket,  ///< The [ key
-            RBracket,  ///< The ] key
-            Semicolon, ///< The ; key
-            Comma,     ///< The , key
-            Period,    ///< The . key
-            Quote,     ///< The ' key
-            Slash,     ///< The / key
-            Backslash, ///< The \ key
-            Tilde,     ///< The ~ key
-            Equal,     ///< The = key
-            Hyphen,    ///< The - key (hyphen)
-            Space,     ///< The Space key
-            Enter,     ///< The Enter/Return keys
-            Backspace, ///< The Backspace key
-            Tab,       ///< The Tabulation key
-            PageUp,    ///< The Page up key
-            PageDown,  ///< The Page down key
-            End,       ///< The End key
-            Home,      ///< The Home key
-            Insert,    ///< The Insert key
-            Delete,    ///< The Delete key
-            Add,       ///< The + key
-            Subtract,  ///< The - key (minus, usually from numpad)
-            Multiply,  ///< The * key
-            Divide,    ///< The / key
-            Left,      ///< Left arrow
-            Right,     ///< Right arrow
-            Up,        ///< Up arrow
-            Down,      ///< Down arrow
-            Numpad0,   ///< The numpad 0 key
-            Numpad1,   ///< The numpad 1 key
-            Numpad2,   ///< The numpad 2 key
-            Numpad3,   ///< The numpad 3 key
-            Numpad4,   ///< The numpad 4 key
-            Numpad5,   ///< The numpad 5 key
-            Numpad6,   ///< The numpad 6 key
-            Numpad7,   ///< The numpad 7 key
-            Numpad8,   ///< The numpad 8 key
-            Numpad9,   ///< The numpad 9 key
-            F1,        ///< The F1 key
-            F2,        ///< The F2 key
-            F3,        ///< The F3 key
-            F4,        ///< The F4 key
-            F5,        ///< The F5 key
-            F6,        ///< The F6 key
-            F7,        ///< The F7 key
-            F8,        ///< The F8 key
-            F9,        ///< The F9 key
-            F10,       ///< The F10 key
-            F11,       ///< The F11 key
-            F12,       ///< The F12 key
-            F13,       ///< The F13 key
-            F14,       ///< The F14 key
-            F15,       ///< The F15 key
-            Pause,     ///< The Pause key
+            Unknown = -1, ///< Unhandled key
+            A,            ///< The A key
+            B,            ///< The B key
+            C,            ///< The C key
+            D,            ///< The D key
+            E,            ///< The E key
+            F,            ///< The F key
+            G,            ///< The G key
+            H,            ///< The H key
+            I,            ///< The I key
+            J,            ///< The J key
+            K,            ///< The K key
+            L,            ///< The L key
+            M,            ///< The M key
+            N,            ///< The N key
+            O,            ///< The O key
+            P,            ///< The P key
+            Q,            ///< The Q key
+            R,            ///< The R key
+            S,            ///< The S key
+            T,            ///< The T key
+            U,            ///< The U key
+            V,            ///< The V key
+            W,            ///< The W key
+            X,            ///< The X key
+            Y,            ///< The Y key
+            Z,            ///< The Z key
+            Num0,         ///< The 0 key
+            Num1,         ///< The 1 key
+            Num2,         ///< The 2 key
+            Num3,         ///< The 3 key
+            Num4,         ///< The 4 key
+            Num5,         ///< The 5 key
+            Num6,         ///< The 6 key
+            Num7,         ///< The 7 key
+            Num8,         ///< The 8 key
+            Num9,         ///< The 9 key
+            Escape,       ///< The Escape key
+            LControl,     ///< The left Control key
+            LShift,       ///< The left Shift key
+            LAlt,         ///< The left Alt key
+            LSystem,      ///< The left OS specific key: window (Windows and Linux), apple (MacOS X), ...
+            RControl,     ///< The right Control key
+            RShift,       ///< The right Shift key
+            RAlt,         ///< The right Alt key
+            RSystem,      ///< The right OS specific key: window (Windows and Linux), apple (MacOS X), ...
+            Menu,         ///< The Menu key
+            LBracket,     ///< The [ key
+            RBracket,     ///< The ] key
+            Semicolon,    ///< The ; key
+            Comma,        ///< The , key
+            Period,       ///< The . key
+            Quote,        ///< The ' key
+            Slash,        ///< The / key
+            Backslash,    ///< The \ key
+            Tilde,        ///< The ~ key
+            Equal,        ///< The = key
+            Hyphen,       ///< The - key (hyphen)
+            Space,        ///< The Space key
+            Enter,        ///< The Enter/Return keys
+            Backspace,    ///< The Backspace key
+            Tab,          ///< The Tabulation key
+            PageUp,       ///< The Page up key
+            PageDown,     ///< The Page down key
+            End,          ///< The End key
+            Home,         ///< The Home key
+            Insert,       ///< The Insert key
+            Delete,       ///< The Delete key
+            Add,          ///< The + key
+            Subtract,     ///< The - key (minus, usually from numpad)
+            Multiply,     ///< The * key
+            Divide,       ///< The / key
+            Left,         ///< Left arrow
+            Right,        ///< Right arrow
+            Up,           ///< Up arrow
+            Down,         ///< Down arrow
+            Numpad0,      ///< The numpad 0 key
+            Numpad1,      ///< The numpad 1 key
+            Numpad2,      ///< The numpad 2 key
+            Numpad3,      ///< The numpad 3 key
+            Numpad4,      ///< The numpad 4 key
+            Numpad5,      ///< The numpad 5 key
+            Numpad6,      ///< The numpad 6 key
+            Numpad7,      ///< The numpad 7 key
+            Numpad8,      ///< The numpad 8 key
+            Numpad9,      ///< The numpad 9 key
+            F1,           ///< The F1 key
+            F2,           ///< The F2 key
+            F3,           ///< The F3 key
+            F4,           ///< The F4 key
+            F5,           ///< The F5 key
+            F6,           ///< The F6 key
+            F7,           ///< The F7 key
+            F8,           ///< The F8 key
+            F9,           ///< The F9 key
+            F10,          ///< The F10 key
+            F11,          ///< The F11 key
+            F12,          ///< The F12 key
+            F13,          ///< The F13 key
+            F14,          ///< The F14 key
+            F15,          ///< The F15 key
+            Pause,        ///< The Pause key
 
             Count, ///< Keep last -- the total number of keyboard keys
         };

--- a/src/ecstasy/integrations/event/inputs/Mouse.hpp
+++ b/src/ecstasy/integrations/event/inputs/Mouse.hpp
@@ -31,7 +31,7 @@ namespace ecstasy::integration::event
       public:
         // LCOV_EXCL_START
 
-        SERIALIZABLE_ENUM(Button, Left, Right, Middle, Extra1, Extra2, Extra3, Count)
+        SERIALIZABLE_ENUM(Button, 0, Left, Right, Middle, Extra1, Extra2, Extra3, Count)
 
         // LCOV_EXCL_STOP
 #ifdef _DOXYGEN_

--- a/src/ecstasy/integrations/user_action/ActionBinding.hpp
+++ b/src/ecstasy/integrations/user_action/ActionBinding.hpp
@@ -41,7 +41,7 @@ namespace ecstasy::integration::user_action
       public:
         // LCOV_EXCL_START
 
-        SERIALIZABLE_ENUM(Type, MouseButton, Key, GamepadButton, GamepadAxis, Count)
+        SERIALIZABLE_ENUM(Type, 0, MouseButton, Key, GamepadButton, GamepadAxis, Count)
 
         // LCOV_EXCL_STOP
 #ifdef _DOXYGEN_

--- a/src/util/serialization/SerializableEnum.hpp
+++ b/src/util/serialization/SerializableEnum.hpp
@@ -14,13 +14,15 @@
 
 #include "foreach.hpp"
 
-#define _ENUM_TO_STRING_ENTRY(name) {Enum::name, #name},
-#define _STRING_TO_ENUM_ENTRY(name) {#name, Enum::name},
+#define _ENUM_TO_STRING_ENTRY(name)  {Enum::name, #name},
+#define _STRING_TO_ENUM_ENTRY(name)  {#name, Enum::name},
+#define _GET_FIRST_ARG(arg1, ...)    arg1
+#define _REMOVE_FIRST_ARG(arg1, ...) __VA_ARGS__
 
-#define SERIALIZABLE_ENUM(NAME, ...)                                                                                 \
+#define SERIALIZABLE_ENUM(NAME, STARTING_AT, ...)                                                                    \
     struct __##NAME {                                                                                                \
       public:                                                                                                        \
-        enum class Enum { __VA_ARGS__ };                                                                             \
+        enum class Enum { _GET_FIRST_ARG(__VA_ARGS__) = STARTING_AT, _REMOVE_FIRST_ARG(__VA_ARGS__) };               \
                                                                                                                      \
         friend inline std::ostream &operator<<(std::ostream &stream, const Enum &e)                                  \
         {                                                                                                            \


### PR DESCRIPTION
# Description

Enum `ecstasy::integration::event::Keyboard::Key` was starting at `Unknown = 0` instead of `Unknown = -1` shifting all keys by one.
Now the macro `SERIALIZABLE_ENUM` takes a `STARTING_AT` parameter to specify the first enum value.

Other enums having the same issues have been modified accordingly. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
