### PR TITLE
Made action binding constructor use templates for implicit enum class conversion

### DIFF
--- a/src/ecstasy/integrations/user_action/ActionBinding.hpp
+++ b/src/ecstasy/integrations/user_action/ActionBinding.hpp
@@ -31,6 +31,18 @@ namespace ecstasy::integration::user_action
     }
 
     ///
+    /// @brief Boolean type trait to check if a type is a valid action id type (enum or size_t).
+    ///
+    /// @tparam E Type to check.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-03-27)
+    ///
+    template <typename E>
+    using is_valid_action_id =
+        typename std::conditional<std::is_enum_v<E>, std::true_type, std::is_same<E, Action::Id>>::type;
+
+    ///
     /// @brief Action binding class, represent a binding between an input and a given action.
     /// Holds the binding type (set to Type::Count if empty), the associated data type and the action id.
     ///
@@ -69,55 +81,68 @@ namespace ecstasy::integration::user_action
         ///
         /// @brief Construct a mouse button action binding.
         ///
+        /// @tparam E Enum or size_t type.
+        ///
         /// @param[in] id Id of the associated action.
         /// @param[in] input Source input.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-25)
         ///
-        constexpr ActionBinding(Action::Id id, event::Mouse::Button input)
-            : type(Type::MouseButton), actionId(id), mouseButton(input)
+        template <typename E, typename = is_valid_action_id<E>>
+        constexpr ActionBinding(E id, event::Mouse::Button input)
+            : type(Type::MouseButton), actionId(static_cast<Action::Id>(id)), mouseButton(input)
         {
         }
 
         ///
         /// @brief Construct a key action binding.
         ///
+        /// @tparam E Enum or size_t type.
+        ///
         /// @param[in] id Id of the associated action.
         /// @param[in] input Source input.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-25)
         ///
-        constexpr ActionBinding(Action::Id id, event::Keyboard::Key input) : type(Type::Key), actionId(id), key(input)
+        template <typename E, typename = is_valid_action_id<E>>
+        constexpr ActionBinding(E id, event::Keyboard::Key input)
+            : type(Type::Key), actionId(static_cast<Action::Id>(id)), key(input)
         {
         }
 
         ///
         /// @brief Construct a gamepad button action binding.
         ///
+        /// @tparam E Enum or size_t type.
+        ///
         /// @param[in] id Id of the associated action.
         /// @param[in] input Source input.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-25)
         ///
-        constexpr ActionBinding(Action::Id id, event::Gamepad::Button input)
-            : type(Type::GamepadButton), actionId(id), gamepadButton(input)
+        template <typename E, typename = is_valid_action_id<E>>
+        constexpr ActionBinding(E id, event::Gamepad::Button input)
+            : type(Type::GamepadButton), actionId(static_cast<Action::Id>(id)), gamepadButton(input)
         {
         }
 
         ///
         /// @brief Construct a gamepad axis action binding.
         ///
+        /// @tparam E Enum or size_t type.
+        ///
         /// @param[in] id Id of the associated action.
         /// @param[in] input Source input.
         ///
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-25)
         ///
-        constexpr ActionBinding(Action::Id id, event::Gamepad::Axis input)
-            : type(Type::GamepadAxis), actionId(id), gamepadAxis(input)
+        template <typename E, typename = is_valid_action_id<E>>
+        constexpr ActionBinding(E id, event::Gamepad::Axis input)
+            : type(Type::GamepadAxis), actionId(static_cast<Action::Id>(id)), gamepadAxis(input)
         {
         }
 

--- a/tests/integration/user_action/tests_ActionBindings.cpp
+++ b/tests/integration/user_action/tests_ActionBindings.cpp
@@ -4,6 +4,8 @@
 namespace event = ecstasy::integration::event;
 namespace user_action = ecstasy::integration::user_action;
 
+enum class Actions : user_action::Action::Id { Action0, Action1, Count };
+
 TEST(ActionBinding, dump)
 {
     {
@@ -15,10 +17,10 @@ Action-0 = [ 'MouseButton->Left', 'Key->A', 'GamepadButton->FaceLeft' ]\n\
 Action-1 = [ 'GamepadAxis->TriggerLeft' ]";
         // clang-format on
 
-        bindings.getBindings().push_back(user_action::ActionBinding(0, event::Mouse::Button::Left));
-        bindings.getBindings().push_back(user_action::ActionBinding(0, event::Keyboard::Key::A));
-        bindings.getBindings().push_back(user_action::ActionBinding(0, event::Gamepad::Button::FaceLeft));
-        bindings.getBindings().push_back(user_action::ActionBinding(1, event::Gamepad::Axis::TriggerLeft));
+        bindings.getBindings().emplace_back(Actions::Action0, event::Mouse::Button::Left);
+        bindings.getBindings().emplace_back(0, event::Keyboard::Key::A);
+        bindings.getBindings().emplace_back(0, event::Gamepad::Button::FaceLeft);
+        bindings.getBindings().emplace_back(1, event::Gamepad::Axis::TriggerLeft);
         ss << bindings.dump();
         GTEST_ASSERT_EQ(ss.str(), expected);
     }


### PR DESCRIPTION
# Description

Updated ActionBinding constructors to be templated and allow using enum class as action id instead of forcing size_t.

Close #121

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Existing tests have been updated using size_t and enum class.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
