### PR TITLE
Introduce gamepad button sequence and combination listeners

### DIFF
--- a/src/ecstasy/integrations/event/inputs/Gamepad.hpp
+++ b/src/ecstasy/integrations/event/inputs/Gamepad.hpp
@@ -14,7 +14,7 @@
 
 #include <array>
 #include <cstdint>
-#include <ostream>
+#include <iostream>
 #include <unordered_map>
 
 #include "util/serialization/SerializableEnum.hpp"

--- a/src/ecstasy/integrations/event/listeners/CMakeLists.txt
+++ b/src/ecstasy/integrations/event/listeners/CMakeLists.txt
@@ -6,7 +6,11 @@ set(SRC
     ${INCROOT}/EventListeners.hpp
     ${INCROOT}/GamepadAxisListener.hpp
     ${INCROOT}/GamepadButtonListener.hpp
+    ${SRCROOT}/GamepadCombinationListener.cpp
+    ${INCROOT}/GamepadCombinationListener.hpp
     ${INCROOT}/GamepadConnectedListener.hpp
+    ${SRCROOT}/GamepadSequenceListener.cpp
+    ${INCROOT}/GamepadSequenceListener.hpp
     ${INCROOT}/include.hpp
     ${SRCROOT}/KeyCombinationListener.cpp
     ${INCROOT}/KeyCombinationListener.hpp

--- a/src/ecstasy/integrations/event/listeners/GamepadCombinationListener.cpp
+++ b/src/ecstasy/integrations/event/listeners/GamepadCombinationListener.cpp
@@ -1,0 +1,68 @@
+///
+/// @file GamepadCombinationListener.cpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2024-03-27
+///
+/// @copyright Copyright (c) ECSTASY 2022 - 2024
+///
+///
+
+#include "GamepadCombinationListener.hpp"
+#include "ecstasy/integrations/event/events/GamepadButtonEvent.hpp"
+
+namespace ecstasy::integration::event
+{
+    GamepadCombinationListener::GamepadCombinationListener(
+        const std::vector<Gamepad::Button> &combination, Callback callback, size_t gamepadId)
+        : _combination(combination), _callback(callback), _gamepadId(gamepadId)
+    {
+        reset();
+    }
+
+    bool GamepadCombinationListener::update(const GamepadButtonEvent &event)
+    {
+        if (event.id != _gamepadId)
+            return false;
+
+        auto it = _buttonStates.find(event.button);
+
+        if (it != _buttonStates.end() && it->second != event.pressed) {
+            if (event.pressed)
+                _validatedButtons++;
+            else
+                _validatedButtons--;
+            it->second = event.pressed;
+            return isComplete();
+        }
+        return false;
+    }
+
+    bool GamepadCombinationListener::isComplete() const
+    {
+        return _validatedButtons == _combination.size();
+    }
+
+    void GamepadCombinationListener::reset()
+    {
+        _validatedButtons = 0;
+        _buttonStates.clear();
+        for (Gamepad::Button button : _combination)
+            _buttonStates[button] = false;
+    }
+
+    void GamepadCombinationListener::operator()(Registry &registry, Entity e, bool force)
+    {
+        if (force || isComplete()) {
+            _callback(registry, e, *this);
+            reset();
+        }
+    }
+
+    void GamepadCombinationListener::setCombination(const std::vector<Gamepad::Button> &newCombination)
+    {
+        _combination = newCombination;
+        reset();
+    }
+} // namespace ecstasy::integration::event

--- a/src/ecstasy/integrations/event/listeners/GamepadCombinationListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/GamepadCombinationListener.hpp
@@ -1,0 +1,226 @@
+///
+/// @file GamepadCombinationListener.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2024-03-27
+///
+/// @copyright Copyright (c) ECSTASY 2022 - 2024
+///
+///
+
+#ifndef ECSTASY_INTEGRATIONS_EVENT_LISTENERS_GAMEPADCOMBINATIONLISTENER_HPP_
+#define ECSTASY_INTEGRATIONS_EVENT_LISTENERS_GAMEPADCOMBINATIONLISTENER_HPP_
+
+#include <functional>
+#include <vector>
+#include "ecstasy/integrations/event/inputs/Gamepad.hpp"
+#include "ecstasy/resources/entity/Entity.hpp"
+
+namespace ecstasy
+{
+    class Registry;
+}
+
+namespace ecstasy::integration::event
+{
+    struct GamepadButtonEvent;
+
+    ///
+    /// @brief Listener of a button combination. Gamepad combination of buttons A, B, X are triggered only when A, B and
+    /// X are pressed at the same time.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-03-27)
+    ///
+    class GamepadCombinationListener {
+      public:
+        /// @brief Callback type.
+        using Callback = std::function<void(Registry &, Entity, const GamepadCombinationListener &)>;
+
+        ///
+        /// @brief Construct a new Button Combination Listener object.
+        ///
+        /// @warning An empty combination will result in undefined behavior, and probably to a crash.
+        /// @note A combination containing only one button is just a button listener.
+        ///
+        /// @param[in] combination Button combination to listen to.
+        /// @param[in] callback Callback called when the combination is validated.
+        /// @param[in] gamepadId Gamepad ID to listen to (default to 0).
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        GamepadCombinationListener(
+            const std::vector<Gamepad::Button> &combination, Callback callback, size_t gamepadId = 0);
+
+        ///
+        /// @brief Default destructor.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        ~GamepadCombinationListener() = default;
+
+        ///
+        /// @brief Update the combination with the given @ref GamepadButtonEvent.
+        ///
+        /// @param[in] event Updating event.
+        ///
+        /// @return bool Whether the combination was validated or not.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        bool update(const GamepadButtonEvent &event);
+
+        ///
+        /// @brief Check whether the combination is complete or not.
+        ///
+        /// @return bool Whether the combination is complete or not.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        bool isComplete() const;
+
+        ///
+        /// @brief Reset the combination completion.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        void reset();
+
+        ///
+        /// @brief Call the callback and @ref reset() if the combination is complete or if @p force.
+        ///
+        /// @param[in] registry Registry to forward to the callback.
+        /// @param[in] e Entity owning this component.
+        /// @param[in] force Whether the callback must be called regardless of the combination completion.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        void operator()(Registry &registry, Entity e, bool force = false);
+
+        ///
+        /// @brief Change the expected combination.
+        ///
+        /// @warning This function reset the combination completion.
+        ///
+        /// @param[in] newCombination New expected combination.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        void setCombination(const std::vector<Gamepad::Button> &newCombination);
+
+        ///
+        /// @brief Get the expected combination.
+        ///
+        /// @return const std::vector<Gamepad::Button>& A const reference to the expected combination.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr const std::vector<Gamepad::Button> &getCombination() const
+        {
+            return _combination;
+        }
+
+        ///
+        /// @brief Get the expected combination.
+        ///
+        /// @warning If the combination is updated, you should call @ref reset().
+        ///
+        /// @return std::vector<Gamepad::Button>& A reference to the expected combination.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr std::vector<Gamepad::Button> &getCombination()
+        {
+            return _combination;
+        }
+
+        ///
+        /// @brief Get the combination completion callback.
+        ///
+        /// @return const Callback& A reference to the combination completion callback.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr const Callback &getCallback() const
+        {
+            return _callback;
+        }
+
+        ///
+        /// @brief Get the count of validated buttons
+        ///
+        /// @return size_t Count of validated buttons.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr size_t getValidatedButtons() const
+        {
+            return _validatedButtons;
+        }
+
+        ///
+        /// @brief Get the Button States.
+        ///
+        /// @note The map button correspond to a combination button and the value is whether it is pressed or not.
+        ///
+        /// @return const std::unordered_map<Gamepad::Button, bool>& A const reference to the ButtonStates map.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr const std::unordered_map<Gamepad::Button, bool> &getButtonStates() const
+        {
+            return _buttonStates;
+        }
+
+        ///
+        /// @brief Get the Gamepad Id
+        ///
+        /// @return constexpr size_t Associated gamepad ID
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-28)
+        ///
+        constexpr size_t getGamepadId() const
+        {
+            return _gamepadId;
+        }
+
+        ///
+        /// @brief Change the Gamepad Id
+        ///
+        /// @warning This function reset the combination completion.
+        ///
+        /// @param[in] gamepadId new gamepad id associated with this listener.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-28)
+        ///
+        void setGamepadId(size_t gamepadId)
+        {
+            _gamepadId = gamepadId;
+            reset();
+        }
+
+      private:
+        std::vector<Gamepad::Button> _combination;
+        std::unordered_map<Gamepad::Button, bool> _buttonStates;
+        size_t _validatedButtons;
+        Callback _callback;
+        size_t _gamepadId;
+    };
+} // namespace ecstasy::integration::event
+
+#endif /* !ECSTASY_INTEGRATIONS_EVENT_LISTENERS_GAMEPADCOMBINATIONLISTENER_HPP_ */

--- a/src/ecstasy/integrations/event/listeners/GamepadSequenceListener.cpp
+++ b/src/ecstasy/integrations/event/listeners/GamepadSequenceListener.cpp
@@ -1,0 +1,66 @@
+///
+/// @file GamepadSequenceListener.cpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2024-03-27
+///
+/// @copyright Copyright (c) ECSTASY 2022 - 2024
+///
+///
+
+#include "GamepadSequenceListener.hpp"
+#include "ecstasy/integrations/event/events/GamepadButtonEvent.hpp"
+
+namespace ecstasy::integration::event
+{
+    GamepadSequenceListener::GamepadSequenceListener(
+        const std::vector<Gamepad::Button> &sequence, Callback callback, size_t gamepadId)
+        : _sequence(sequence), _callback(callback), _gamepadId(gamepadId)
+    {
+        reset();
+    }
+
+    bool GamepadSequenceListener::update(const GamepadButtonEvent &event)
+    {
+        if (event.id != _gamepadId)
+            return false;
+
+        if (event.pressed) {
+            if (_heldButton == Gamepad::Button::Unknown && event.button == _sequence.at(_validatedButtons.size()))
+                _heldButton = event.button;
+            else if (_heldButton != Gamepad::Button::Unknown || !_validatedButtons.empty()) {
+                reset();
+                /// In case the failing key is the first key of the sequence we must start again the sequence.
+                return update(event);
+            }
+        } else {
+            if (_heldButton != Gamepad::Button::Unknown && _heldButton == event.button) {
+                _validatedButtons.push_back(_heldButton);
+                _heldButton = Gamepad::Button::Unknown;
+                return isComplete();
+            }
+        }
+        return false;
+    }
+
+    bool GamepadSequenceListener::isComplete() const
+    {
+        return _sequence.size() == _validatedButtons.size();
+    }
+
+    void GamepadSequenceListener::operator()(Registry &registry, Entity e, bool force)
+    {
+        if (force || isComplete()) {
+            _callback(registry, e, *this);
+            reset();
+        }
+    }
+
+    void GamepadSequenceListener::setSequence(const std::vector<Gamepad::Button> &newSequence)
+    {
+        _sequence = newSequence;
+        reset();
+    }
+
+} // namespace ecstasy::integration::event

--- a/src/ecstasy/integrations/event/listeners/GamepadSequenceListener.hpp
+++ b/src/ecstasy/integrations/event/listeners/GamepadSequenceListener.hpp
@@ -1,0 +1,234 @@
+///
+/// @file GamepadSequenceListener.hpp
+/// @author Andréas Leroux (andreas.leroux@epitech.eu)
+/// @brief
+/// @version 1.0.0
+/// @date 2024-03-27
+///
+/// @copyright Copyright (c) ECSTASY 2022 - 2024
+///
+///
+
+#ifndef ECSTASY_INTEGRATIONS_EVENT_LISTENERS_GAMEPADSEQUENCELISTENER_HPP_
+#define ECSTASY_INTEGRATIONS_EVENT_LISTENERS_GAMEPADSEQUENCELISTENER_HPP_
+
+#include <functional>
+#include <vector>
+#include "ecstasy/integrations/event/inputs/Gamepad.hpp"
+#include "ecstasy/resources/entity/Entity.hpp"
+
+namespace ecstasy
+{
+    class Registry;
+}
+
+namespace ecstasy::integration::event
+{
+    struct GamepadButtonEvent;
+
+    ///
+    /// @brief Listener of a button sequence. Button sequences of buttons A, B, X are triggered only when A, B and X are
+    /// pressed and released one at a time (A, then B, then X). If any other button is pressed while waiting for a
+    /// button release or if the button was not expected, the validated buttons are reset: A, B, Y, X will not work
+    /// because the Y reset the sequence.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-03-27)
+    ///
+    class GamepadSequenceListener {
+      public:
+        /// @brief Callback type.
+        using Callback = std::function<void(Registry &, Entity, const GamepadSequenceListener &)>;
+
+        ///
+        /// @brief Construct a new Gamepad Sequence Listener object.
+        ///
+        /// @warning An empty sequence will result in undefined behavior, and probably to a crash.
+        /// @note A sequence containing only one button is just a button listener.
+        ///
+        /// @param[in] sequence Button sequence to listen to.
+        /// @param[in] callback Callback called when the sequence is validated.
+        /// @param[in] gamepadId Gamepad ID to listen to (default to 0).
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        GamepadSequenceListener(const std::vector<Gamepad::Button> &sequence, Callback callback, size_t gamepadId = 0);
+
+        ///
+        /// @brief Default destructor.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        ~GamepadSequenceListener() = default;
+
+        ///
+        /// @brief Update the sequence with the given @ref GamepadButtonEvent.
+        ///
+        /// @param[in] event Updating event.
+        ///
+        /// @return bool Whether the sequence was validated or not.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        bool update(const GamepadButtonEvent &event);
+
+        ///
+        /// @brief Check whether the sequence is complete or not.
+        ///
+        /// @return bool Whether the sequence is complete or not.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        bool isComplete() const;
+
+        ///
+        /// @brief Reset the sequence completion.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr void reset()
+        {
+            _validatedButtons.clear();
+            _heldButton = Gamepad::Button::Unknown;
+        }
+
+        ///
+        /// @brief Call the callback and @ref reset() if the sequence is complete or if @p force.
+        ///
+        /// @param[in] registry Registry to forward to the callback.
+        /// @param[in] e Entity owning this component.
+        /// @param[in] force Whether the callback must be called regardless of the sequence completion.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        void operator()(Registry &registry, Entity e, bool force = false);
+
+        ///
+        /// @brief Change the expected sequence.
+        ///
+        /// @warning This function reset the sequence completion.
+        ///
+        /// @param[in] newSequence New expected sequence.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        void setSequence(const std::vector<Gamepad::Button> &newSequence);
+
+        ///
+        /// @brief Get the expected sequence.
+        ///
+        /// @return const std::vector<Gamepad::Button>& A const reference to the expected sequence.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr const std::vector<Gamepad::Button> &getSequence() const
+        {
+            return _sequence;
+        }
+
+        ///
+        /// @brief Get the expected sequence.
+        ///
+        /// @warning If the sequence is updated, you should call @ref reset().
+        ///
+        /// @return std::vector<Gamepad::Button>& A reference to the expected sequence.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr std::vector<Gamepad::Button> &getSequence()
+        {
+            return _sequence;
+        }
+
+        ///
+        /// @brief Get the sequence completion callback.
+        ///
+        /// @return const Callback& A reference to the sequence completion callback.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr const Callback &getCallback() const
+        {
+            return _callback;
+        }
+
+        ///
+        /// @brief Get the button held.
+        ///
+        /// @note The button held is the current sequence button pressed but not yet released (it will be pushed in the
+        /// validated buttons on release)
+        ///
+        /// @return Gamepad::Button Button held if any, @ref Gamepad::Button::Unknown otherwise.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr Gamepad::Button getHeldButton() const
+        {
+            return _heldButton;
+        }
+
+        ///
+        /// @brief Get the Validated Buttons.
+        ///
+        /// @note Use this function to see the progress of the sequence.
+        ///
+        /// @return const std::vector<Gamepad::Button>& A const reference to the validated buttons vector.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-27)
+        ///
+        constexpr const std::vector<Gamepad::Button> &getValidatedButtons() const
+        {
+            return _validatedButtons;
+        }
+
+        ///
+        /// @brief Get the Gamepad Id
+        ///
+        /// @return constexpr size_t Associated gamepad ID
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-28)
+        ///
+        constexpr size_t getGamepadId() const
+        {
+            return _gamepadId;
+        }
+
+        ///
+        /// @brief Change the Gamepad Id
+        ///
+        /// @warning This function reset the combination completion.
+        ///
+        /// @param[in] gamepadId new gamepad id associated with this listener.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-03-28)
+        ///
+        constexpr void setGamepadId(size_t gamepadId)
+        {
+            _gamepadId = gamepadId;
+            reset();
+        }
+
+      private:
+        std::vector<Gamepad::Button> _sequence;
+        std::vector<Gamepad::Button> _validatedButtons;
+        Gamepad::Button _heldButton;
+        Callback _callback;
+        size_t _gamepadId;
+    };
+} // namespace ecstasy::integration::event
+
+#endif /* !ECSTASY_INTEGRATIONS_EVENT_LISTENERS_GAMEPADSEQUENCELISTENER_HPP_ */

--- a/tests/integration/event/tests_Gamepad.cpp
+++ b/tests/integration/event/tests_Gamepad.cpp
@@ -7,7 +7,9 @@
 #include "ecstasy/integrations/event/inputs/Gamepads.hpp"
 #include "ecstasy/integrations/event/listeners/GamepadAxisListener.hpp"
 #include "ecstasy/integrations/event/listeners/GamepadButtonListener.hpp"
+#include "ecstasy/integrations/event/listeners/GamepadCombinationListener.hpp"
 #include "ecstasy/integrations/event/listeners/GamepadConnectedListener.hpp"
+#include "ecstasy/integrations/event/listeners/GamepadSequenceListener.hpp"
 #include "ecstasy/registry/Registry.hpp"
 #include "ecstasy/storages/MapStorage.hpp"
 
@@ -131,4 +133,207 @@ TEST(Event, GamepadAxis)
     GTEST_ASSERT_EQ(gamepadsState.get(0).getAxisValue(event::Gamepad::Axis::TriggerLeft), -1.f);
     event::EventsManager::handleEvent(registry, event::GamepadAxisEvent(0, event::Gamepad::Axis::TriggerLeft, 0.3f));
     GTEST_ASSERT_EQ(gamepadsState.get(0).getAxisValue(event::Gamepad::Axis::TriggerLeft), 0.3f);
+}
+
+TEST(Event, GamepadSequence)
+{
+    Registry registry;
+    int sequenceCount = 0;
+
+    /// Sequence ABC listener
+    auto &sequenceListener =
+        registry.getStorageSafe<event::GamepadSequenceListener>()
+            [registry.entityBuilder()
+                    .with<event::GamepadSequenceListener>(
+                        std::initializer_list<event::Gamepad::Button>{event::Gamepad::Button::FaceDown,
+                            event::Gamepad::Button::FaceRight, event::Gamepad::Button::FaceUp},
+                        [&sequenceCount](Registry &r, Entity e, const event::GamepadSequenceListener &event) {
+                            (void)r;
+                            (void)e;
+                            (void)event;
+                            sequenceCount++;
+                        })
+                    .build()
+                    .getIndex()];
+    sequenceListener.setSequence(
+        {event::Gamepad::Button::FaceDown, event::Gamepad::Button::FaceRight, event::Gamepad::Button::FaceUp});
+
+    /// Initial state
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// Call without force innaccessible
+    sequenceListener(registry, registry.getEntity(0));
+    GTEST_ASSERT_EQ(sequenceCount, 0);
+    sequenceListener(registry, registry.getEntity(0), true);
+    GTEST_ASSERT_EQ(sequenceCount, 1);
+
+    /// First sequence key pressed
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+    /// First sequence key released -> key is validated
+    event::EventsManager::handleEvent(registry, event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_EQ(static_cast<size_t>(sequenceListener.getValidatedButtons()[0]),
+        static_cast<size_t>(event::Gamepad::Button::FaceDown));
+
+    /// Following key without the handleEvent
+    GTEST_ASSERT_FALSE(sequenceListener.update(event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceRight)));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::FaceRight));
+    GTEST_ASSERT_EQ(sequenceListener.getValidatedButtons().size(), 1);
+
+    GTEST_ASSERT_FALSE(
+        sequenceListener.update(event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceRight)));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_EQ(static_cast<size_t>(sequenceListener.getValidatedButtons()[1]),
+        static_cast<size_t>(event::Gamepad::Button::FaceRight));
+
+    /// Final key
+    GTEST_ASSERT_FALSE(sequenceListener.update(event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceUp)));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::FaceUp));
+    GTEST_ASSERT_EQ(sequenceListener.getValidatedButtons().size(), 2);
+    /// Sequence completed and called
+    event::EventsManager::handleEvent(registry, event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceUp));
+    GTEST_ASSERT_EQ(sequenceCount, 2);
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// Invalid first key pressed
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceLeft));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// First sequence key pressed
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// Key pressed while waiting release
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceLeft));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// First sequence key pressed and released
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceDown));
+    event::EventsManager::handleEvent(registry, event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_FALSE(sequenceListener.getValidatedButtons().empty());
+
+    /// Invalid Key pressed in the sequence
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceLeft));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// Unhandled release: no held key -> no change
+    event::EventsManager::handleEvent(registry, event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::Unknown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+
+    /// Unhandled release: key doesn't match the held key -> no change
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+    event::EventsManager::handleEvent(registry, event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceLeft));
+    GTEST_ASSERT_FALSE(sequenceListener.isComplete());
+    GTEST_ASSERT_EQ(
+        static_cast<size_t>(sequenceListener.getHeldButton()), static_cast<size_t>(event::Gamepad::Button::FaceDown));
+    GTEST_ASSERT_TRUE(sequenceListener.getValidatedButtons().empty());
+}
+
+TEST(Event, GamepadCombination)
+{
+    Registry registry;
+    int combinationCount = 0;
+
+    /// Sequence ABC listener
+    auto &combinationListener =
+        registry.getStorageSafe<event::GamepadCombinationListener>()
+            [registry.entityBuilder()
+                    .with<event::GamepadCombinationListener>(
+                        std::initializer_list<event::Gamepad::Button>{event::Gamepad::Button::FaceDown,
+                            event::Gamepad::Button::FaceRight, event::Gamepad::Button::FaceUp},
+                        [&combinationCount](Registry &r, Entity e, const event::GamepadCombinationListener &event) {
+                            (void)r;
+                            (void)e;
+                            (void)event;
+                            combinationCount++;
+                        })
+                    .build()
+                    .getIndex()];
+    combinationListener.setCombination(
+        {event::Gamepad::Button::FaceDown, event::Gamepad::Button::FaceRight, event::Gamepad::Button::FaceUp});
+
+    /// Initial state
+    GTEST_ASSERT_FALSE(combinationListener.isComplete());
+    GTEST_ASSERT_EQ(combinationListener.getValidatedButtons(), 0);
+
+    /// Call without force innaccessible
+    combinationListener(registry, registry.getEntity(0));
+    GTEST_ASSERT_EQ(combinationCount, 0);
+    combinationListener(registry, registry.getEntity(0), true);
+    GTEST_ASSERT_EQ(combinationCount, 1);
+
+    /// Combination key pressed
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceRight));
+    GTEST_ASSERT_FALSE(combinationListener.isComplete());
+    GTEST_ASSERT_EQ(combinationListener.getValidatedButtons(), 1);
+
+    /// Unhandled key, no changes
+    GTEST_ASSERT_FALSE(
+        combinationListener.update(event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceLeft)));
+
+    /// Same key is pressed again, no changes
+    GTEST_ASSERT_FALSE(
+        combinationListener.update(event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceRight)));
+    GTEST_ASSERT_FALSE(combinationListener.isComplete());
+    GTEST_ASSERT_EQ(combinationListener.getValidatedButtons(), 1);
+
+    /// Another combination key pressed
+    GTEST_ASSERT_FALSE(
+        combinationListener.update(event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceDown)));
+    GTEST_ASSERT_FALSE(combinationListener.isComplete());
+    GTEST_ASSERT_EQ(combinationListener.getValidatedButtons(), 2);
+
+    /// A combination key is released
+    GTEST_ASSERT_FALSE(
+        combinationListener.update(event::GamepadButtonReleasedEvent(0, event::Gamepad::Button::FaceDown)));
+    GTEST_ASSERT_FALSE(combinationListener.isComplete());
+    GTEST_ASSERT_EQ(combinationListener.getValidatedButtons(), 1);
+
+    /// Missing keys are pressed
+    GTEST_ASSERT_FALSE(
+        combinationListener.update(event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceDown)));
+    event::EventsManager::handleEvent(registry, event::GamepadButtonPressedEvent(0, event::Gamepad::Button::FaceUp));
+    GTEST_ASSERT_EQ(combinationCount, 2);
+    GTEST_ASSERT_FALSE(combinationListener.isComplete());
+    GTEST_ASSERT_EQ(combinationListener.getValidatedButtons(), 0);
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Add gamepad button sequence and combination listeners similarly to keyboard key sequence/combination equivalent listeners.
Gamepad listeners are associated to a gamepad id.

<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

Close #78 

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!--
If you ran accross some minor bugs and fixed them please list them below and explain what was the issue (what/when was happening and why).
If there is no minor fixes feel free to delete this section.
-->

## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [x] New tests written
- [ ] Existing tests updated
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
