### PR TITLE
Made shared recursive mutex really recursive

### DIFF
--- a/doc/TechnicalImplementation.md
+++ b/doc/TechnicalImplementation.md
@@ -194,9 +194,6 @@ The query parts have an `AutoLock` boolean template parameter. If it is set to t
    @note
    The mutex is recursive mostly because it is hard for ecstasy (meaning for my little brain) to detect whether a queryable is already locked by the current query or not, especially when dealing with the same queryable multiple times in the same query because of modifiers. Therefore it will be locked multiple times by the same query.
 
-   @warning
-   As said above the same lockable can be locked multiple times by the same query. You can easily have a deadlock if in the same query you request a const queryable and the non const version. Because it will try to perform an exclusive lock and a shared lock, which are not compatible. See [SharedRecursiveMutex](@ref ecstasy::thread::SharedRecursiveMutex) documentation.
-
 3. [LockableView](@ref ecstasy::thread::LockableView) instanciation
 
    [LockableView](@ref ecstasy::thread::LockableView) (LV, I'm not too lazy for this parenthesis but too lazy to write [LockableView](@ref ecstasy::thread::LockableView)) can be instanciated at multiple times depending of the query.

--- a/src/ecstasy/integrations/event/inputs/Gamepads.hpp
+++ b/src/ecstasy/integrations/event/inputs/Gamepads.hpp
@@ -34,7 +34,7 @@ namespace ecstasy::integration::event
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-18)
         ///
-        constexpr Gamepads()
+        Gamepads()
         {
             for (size_t i = 0; i < GamepadCount; i++)
                 _gamepads[i] = Gamepad(i);

--- a/src/ecstasy/integrations/event/inputs/Keyboard.hpp
+++ b/src/ecstasy/integrations/event/inputs/Keyboard.hpp
@@ -156,7 +156,7 @@ namespace ecstasy::integration::event
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-16)
         ///
-        constexpr Keyboard() : _keys({false}){};
+        Keyboard() : _keys({false}){};
 
         ///
         /// @brief Destroy the Keyboard.

--- a/src/ecstasy/integrations/event/inputs/Mouse.hpp
+++ b/src/ecstasy/integrations/event/inputs/Mouse.hpp
@@ -62,7 +62,7 @@ namespace ecstasy::integration::event
         /// @author Andréas Leroux (andreas.leroux@epitech.eu)
         /// @since 1.0.0 (2022-11-05)
         ///
-        constexpr Mouse() : _buttons({false}), _x(0), _y(0){};
+        Mouse() : _buttons({false}), _x(0), _y(0){};
 
         ///
         /// @brief Destroy the Mouse resource.

--- a/src/ecstasy/thread/SharedRecursiveMutex.cpp
+++ b/src/ecstasy/thread/SharedRecursiveMutex.cpp
@@ -16,10 +16,19 @@ namespace ecstasy::thread
     void SharedRecursiveMutex::lock(void)
     {
         std::thread::id this_id = std::this_thread::get_id();
+
         if (_owner == this_id) {
             // recursive locking
             _lock_count++;
         } else {
+            // Unlock the shared lock if any
+            if (get_shared_lock_count() > 0) {
+                _shared_mutex.unlock_shared();
+                // Add a count to avoid the unlock_shared() to be called before the unlock()
+                // While the thread has exclusive lock, there is no real shared_lock, therefore calling unlock_shared()
+                // would cause an error
+                ++_shared_locks[this_id];
+            }
             // normal locking
             _shared_mutex.lock();
             _owner = this_id;
@@ -29,7 +38,17 @@ namespace ecstasy::thread
 
     void SharedRecursiveMutex::lock_shared(void) const
     {
-        _shared_mutex.lock_shared();
+        std::thread::id this_id = std::this_thread::get_id();
+        // Increment the shared lock count for this thread
+        int &shared_lock_count = ++_shared_locks[this_id];
+
+        // If it is the first shared lock, the count is set to 1 by incrementing the 0 default initialized value
+        if (shared_lock_count == 1) {
+            if (_owner != this_id)
+                _shared_mutex.lock_shared();
+            else
+                ++shared_lock_count;
+        }
     }
 
     void SharedRecursiveMutex::unlock(void)
@@ -42,12 +61,38 @@ namespace ecstasy::thread
             _owner = std::thread::id();
             _lock_count = 0;
             _shared_mutex.unlock();
+            // Apply the remaining shared locks that were made before/inside the exclusive lock
+            if (get_shared_lock_count() > 0) {
+                // Remove the count added in lock() and call remaininc lock_shared()
+                if (--_shared_locks[std::this_thread::get_id()] > 0)
+                    _shared_mutex.lock_shared();
+            }
         }
     }
 
     void SharedRecursiveMutex::unlock_shared(void) const
     {
-        _shared_mutex.unlock_shared();
+        int &_shared_lock_count = --_shared_locks.at(std::this_thread::get_id());
+
+        // If it was the last shared lock, unlock the shared mutex
+        if (_shared_lock_count == 0)
+            _shared_mutex.unlock_shared();
+    }
+
+    int SharedRecursiveMutex::get_shared_lock_count(void) const noexcept
+    {
+        // Better than handling exceptions
+        if (has_shared_lock())
+            return _shared_locks.at(std::this_thread::get_id());
+        else
+            return 0;
+    }
+
+    bool SharedRecursiveMutex::has_shared_lock(void) const noexcept
+    {
+        return const_cast<const std::unordered_map<std::thread::id, int> &>(_shared_locks)
+                   .find(std::this_thread::get_id())
+            != _shared_locks.cend();
     }
 
 } // namespace ecstasy::thread

--- a/tests/thread/tests_SharedRecursiveMutex.cpp
+++ b/tests/thread/tests_SharedRecursiveMutex.cpp
@@ -10,12 +10,15 @@ TEST(SharedRecursiveMutex, exclusive_lock)
     // No initialisation because of inheritance issue, to fix in a later commit with the whole thread safe integration
     // GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
     // GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
 
     /// Exclusive lock
     mutex.lock();
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
     GTEST_ASSERT_EQ(mutex.get_lock_count(), 1);
     GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
     mutex.unlock();
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
     GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
     GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
 }
@@ -28,63 +31,110 @@ TEST(SharedRecursiveMutex, shared_locks)
     // No initialisation because of inheritance issue, to fix in a later commit with the whole thread safe integration
     // GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
     // GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
     mutex.lock();
     mutex.unlock();
 
     /// Shared lock
     mutex.lock_shared();
     GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
     GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
     mutex.unlock_shared();
     GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
     GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
 
     /// Const lock leads to shared lock/unlock
     cmutex.lock();
     GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
     GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
     cmutex.unlock();
     GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
     GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
 }
 
-TEST(SharedRecursiveMutex, recursive_exclusive_lock)
+TEST(SharedRecursiveMutex, recursive_locks)
 {
     SharedRecursiveMutex mutex;
 
     // No initialisation because of inheritance issue, to fix in a later commit with the whole thread safe integration
     // GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
     // GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
+    GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
 
     /// Exclusive recursive locks
     /// Scopes are only for better readability, nothing to do with scope variables
     {
         mutex.lock();
         GTEST_ASSERT_EQ(mutex.get_lock_count(), 1);
+        GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
         GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
 
         {
             mutex.lock();
             GTEST_ASSERT_EQ(mutex.get_lock_count(), 2);
+            GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
             GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
+
+            {
+                // Should not deadlock
+                mutex.lock_shared();
+                // 2 because the exclusive lock increments the shared lock count for internal purposes
+                GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 2);
+
+                mutex.unlock_shared();
+                // The count will be released to 0 by the final unlock() call
+                GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
+            }
 
             {
                 mutex.lock();
                 GTEST_ASSERT_EQ(mutex.get_lock_count(), 3);
+                GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
                 GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
 
                 mutex.unlock();
                 GTEST_ASSERT_EQ(mutex.get_lock_count(), 2);
+                GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
                 GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
             }
 
             mutex.unlock();
             GTEST_ASSERT_EQ(mutex.get_lock_count(), 1);
+            GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
             GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
         }
 
+        // Calls lock shared within the exclusive lock
+        mutex.lock_shared();
+        GTEST_ASSERT_EQ(mutex.get_lock_count(), 1);
+        GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
+        // 2 because the exclusive lock increments the shared lock count for internal purposes
+        GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 2);
+
         mutex.unlock();
         GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
+        GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
+        GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
+
+        // Calls lock within the shared lock
+        mutex.lock();
+        GTEST_ASSERT_EQ(mutex.get_lock_count(), 1);
+        GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 2);
+        GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
+
+        mutex.unlock_shared();
+        GTEST_ASSERT_EQ(mutex.get_lock_count(), 1);
+        GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 1);
+        GTEST_ASSERT_EQ(mutex.get_owner(), std::this_thread::get_id());
+
+        // Finally nothing is locked
+        mutex.unlock();
+        GTEST_ASSERT_EQ(mutex.get_lock_count(), 0);
+        GTEST_ASSERT_EQ(mutex.get_shared_lock_count(), 0);
         GTEST_ASSERT_EQ(mutex.get_owner(), std::thread::id());
     }
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Now allow to request shared lock within exclusive lock, or exclusive lock within the shared lock **if the locks are on the same thread**.
To sum up, it avoid any deadlock from the same thread locking itself twice whatever the lock type is, deadlock risk from misuse of lock with multiple threads is still existing (Cannot prevent everything)


<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

Close #140

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] New tests written
- [x] Existing tests updated
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
