### PR TITLE
Auto lock resources in registry.getResource following RAII principle

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -8,15 +8,17 @@ option(BUILD_SHARED_LIBS "Whether ecstasy must be built as a shared library or n
 
 ## Multi-Threading options
 option(ECSTASY_THREAD_SAFE "Enable thread safety for all lockable resources and storages. 
-This is the combination of ECSTASY_AUTO_LOCK, ECSTASY_LOCKABLE_RESOURCES and  ECSTASY_LOCKABLE_STORAGES." OFF)
+This is the combination of ECSTASY_AUTO_LOCK, ECSTASY_AUTO_LOCK_RESOURCES, ECSTASY_LOCKABLE_RESOURCES and  ECSTASY_LOCKABLE_STORAGES." OFF)
 
-option(ECSTASY_AUTO_LOCK "Registry queries and modifiers (RegistryModifier) lock Lockable queryables by default (implicit thread safety). 
-This doesn't affect the default false value in the ecstasy::query namespace. (QueryImplementation and ecstasy::query::modifier::*)" OFF)
 option(ECSTASY_LOCKABLE_RESOURCES "Resources inherit from SharedRecursiveMutex and are therefore lockable." OFF)
 option(ECSTASY_LOCKABLE_STORAGES "Storages inherit from SharedRecursiveMutex and are therefore lockable." OFF)
+option(ECSTASY_AUTO_LOCK "Registry queries and modifiers (RegistryModifier) lock Lockable queryables by default (implicit thread safety). 
+This doesn't affect the default false value in the ecstasy::query namespace. (QueryImplementation and ecstasy::query::modifier::*)" OFF)
+CMAKE_DEPENDENT_OPTION(ECSTASY_AUTO_LOCK_RESOURCES "Resources are locked by default when calling registry.getResource (implicit thread safety)." OFF ECSTASY_LOCKABLE_RESOURCES OFF)
 
 if (${ECSTASY_THREAD_SAFE})
     set(ECSTASY_AUTO_LOCK ON)
+    set(ECSTASY_AUTO_LOCK_RESOURCES ON)
     set(ECSTASY_LOCKABLE_RESOURCES ON)
     set(ECSTASY_LOCKABLE_STORAGES ON)
 endif()
@@ -44,9 +46,10 @@ list(APPEND CMAKE_MESSAGE_INDENT "  ")
     ## Multi-Threading
     message(STATUS "Multi-Threading:")
     list(APPEND CMAKE_MESSAGE_INDENT "  ")
-        message(STATUS "Auto lock: ${ECSTASY_AUTO_LOCK}")
         message(STATUS "Lockable resources: ${ECSTASY_LOCKABLE_RESOURCES}")
         message(STATUS "Lockable storages: ${ECSTASY_LOCKABLE_STORAGES}")
+        message(STATUS "Auto lock: ${ECSTASY_AUTO_LOCK}")
+        message(STATUS "Auto lock resources: ${ECSTASY_AUTO_LOCK_RESOURCES}")
     list(POP_BACK CMAKE_MESSAGE_INDENT)
     ## Integrations
     message(STATUS "Integrations:")

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -92,17 +92,18 @@ _I am writing these lines because I suffered too much with CMake and if it can s
 You can find more details about the options and their dependencies in [Options.cmake](/cmake/Options.cmake). <br>
 _In case this documentation is not up to date with the [Options.cmake](/cmake/Options.cmake) file, open an issue._
 
-| Option Name                          | Description                                                                                                        | Default Value |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------- |
-| BUILD_TEST_SUITE                     | Build the test suite along the ecstasy code                                                                        | OFF           |
-| ENABLE_COVERAGE                      | Enable code coverage tracking. Must be set with **BUILD_TEST_SUITE** to have the tests coverage                    | OFF           |
-| BUILD_SHARED_LIBS                    | Build Ecstasy as shared libaries                                                                                   | OFF           |
-| ECSTASY_THREAD_SAFE                  | Combination of **ECSTASY_AUTO_LOCK**, **ECSTASY_LOCKABLE_RESOURCES** and **ECSTASY_LOCKABLE_STORAGES**             | OFF           |
-| ECSTASY_AUTO_LOCK                    | Auto lock lockable queryables in registry queries                                                                  | OFF           |
-| ECSTASY_LOCKABLE_RESOURCES           | Make [Resource](@ref ecstasy::Resource) inherit [SharedRecursiveMutex](@ref ecstasy::thread::SharedRecursiveMutex) | OFF           |
-| ECSTASY_LOCKABLE_STORAGES            | Make [IStorage](@ref ecstasy::IStorage) inherit [SharedRecursiveMutex](@ref ecstasy::thread::SharedRecursiveMutex) | OFF           |
-| ECSTASY_INTEGRATIONS_EVENT           | Enable the Event integration                                                                                       | OFF           |
-| ECSTASY_INTEGRATIONS_SFML            | Enable the Sfml integration. Requires **ECSTASY_INTEGRATIONS_EVENT**                                               | OFF           |
-| ECSTASY_INTEGRATIONS_SFML_BUILD_DEMO | Enable the Sfml integration demos. Requires **ECSTASY_INTEGRATIONS_SFML**                                          | OFF           |
-| ECSTASY_INTEGRATIONS_USER_ACTION     | Enable the User Actions integration. Requires **ECSTASY_INTEGRATIONS_EVENT**                                       | OFF           |
-| ECSTASY_SERIALIZER_TOML              | Enable the Toml Serializer. Force set if **ECSTASY_INTEGRATIONS_USER_ACTION** is set                               | OFF           |
+| Option Name                          | Description                                                                                                                             | Default Value |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| BUILD_TEST_SUITE                     | Build the test suite along the ecstasy code                                                                                             | OFF           |
+| ENABLE_COVERAGE                      | Enable code coverage tracking. Must be set with **BUILD_TEST_SUITE** to have the tests coverage                                         | OFF           |
+| BUILD_SHARED_LIBS                    | Build Ecstasy as shared libaries                                                                                                        | OFF           |
+| ECSTASY_THREAD_SAFE                  | Combination of **ECSTASY_AUTO_LOCK**, **ECSTASY_AUTO_LOCK_RESOURCES**, **ECSTASY_LOCKABLE_RESOURCES** and **ECSTASY_LOCKABLE_STORAGES** | OFF           |
+| ECSTASY_LOCKABLE_RESOURCES           | Make [Resource](@ref ecstasy::Resource) inherit [SharedRecursiveMutex](@ref ecstasy::thread::SharedRecursiveMutex)                      | OFF           |
+| ECSTASY_LOCKABLE_STORAGES            | Make [IStorage](@ref ecstasy::IStorage) inherit [SharedRecursiveMutex](@ref ecstasy::thread::SharedRecursiveMutex)                      | OFF           |
+| ECSTASY_AUTO_LOCK                    | Auto lock lockable queryables in registry queries                                                                                       | OFF           |
+| ECSTASY_AUTO_LOCK_RESOURCES          | Auto lock resources with registry.getResource. Requires **ECSTASY_LOCKABLE_RESOURCES**                                                  | OFF           |
+| ECSTASY_INTEGRATIONS_EVENT           | Enable the Event integration                                                                                                            | OFF           |
+| ECSTASY_INTEGRATIONS_SFML            | Enable the Sfml integration. Requires **ECSTASY_INTEGRATIONS_EVENT**                                                                    | OFF           |
+| ECSTASY_INTEGRATIONS_SFML_BUILD_DEMO | Enable the Sfml integration demos. Requires **ECSTASY_INTEGRATIONS_SFML**                                                               | OFF           |
+| ECSTASY_INTEGRATIONS_USER_ACTION     | Enable the User Actions integration. Requires **ECSTASY_INTEGRATIONS_EVENT**                                                            | OFF           |
+| ECSTASY_SERIALIZER_TOML              | Enable the Toml Serializer. Force set if **ECSTASY_INTEGRATIONS_USER_ACTION** is set                                                    | OFF           |

--- a/src/ecstasy/config.hpp.in
+++ b/src/ecstasy/config.hpp.in
@@ -21,6 +21,7 @@
 
 // Multi threading options
 #cmakedefine ECSTASY_AUTO_LOCK
+#cmakedefine ECSTASY_AUTO_LOCK_RESOURCES
 #cmakedefine ECSTASY_LOCKABLE_RESOURCES
 #cmakedefine ECSTASY_LOCKABLE_STORAGES
 
@@ -30,6 +31,12 @@ namespace ecstasy::thread
     static constexpr bool AUTO_LOCK_DEFAULT = true;
 #else
     static constexpr bool AUTO_LOCK_DEFAULT = false;
+#endif
+
+#ifdef ECSTASY_AUTO_LOCK_RESOURCES
+    static constexpr bool AUTO_LOCK_RESOURCES_DEFAULT = true;
+#else
+    static constexpr bool AUTO_LOCK_RESOURCES_DEFAULT = false;
 #endif
 } // namespace ecstasy::thread
 

--- a/src/ecstasy/integrations/event/EventsManager.cpp
+++ b/src/ecstasy/integrations/event/EventsManager.cpp
@@ -90,15 +90,15 @@ namespace ecstasy::integration::event
                 callListeners(registry, event.mouseButton);
 
                 if (registry.hasResource<Mouse>())
-                    registry.getResource<Mouse>().setButtonState(event.mouseButton.button, event.mouseButton.pressed);
+                    registry.getResource<Mouse>()->setButtonState(event.mouseButton.button, event.mouseButton.pressed);
                 break;
             case Event::Type::MouseWheelScrolled: callListeners(registry, event.mouseWheel); break;
             case Event::Type::MouseMoved:
                 callListeners(registry, event.mouseMove);
 
                 if (registry.hasResource<Mouse>()) {
-                    Mouse &mouse = registry.getResource<Mouse>();
-                    mouse.setPosition(event.mouseMove.x + mouse.getX(), event.mouseMove.y + mouse.getY());
+                    RR<Mouse> mouse = registry.getResource<Mouse>();
+                    mouse->setPosition(event.mouseMove.x + mouse->getX(), event.mouseMove.y + mouse->getY());
                 }
                 break;
             case Event::Type::KeyPressed:
@@ -106,7 +106,7 @@ namespace ecstasy::integration::event
                 callKeyListeners(registry, event.key);
 
                 if (registry.hasResource<Keyboard>())
-                    registry.getResource<Keyboard>().setKeyState(event.key.key, event.key.pressed);
+                    registry.getResource<Keyboard>()->setKeyState(event.key.key, event.key.pressed);
                 break;
             case Event::Type::TextEntered: callListeners(registry, event.text); break;
             case Event::Type::GamepadButtonPressed:
@@ -115,7 +115,7 @@ namespace ecstasy::integration::event
 
                 if (registry.hasResource<Gamepads>())
                     registry.getResource<Gamepads>()
-                        .get(event.gamepadButton.id)
+                        ->get(event.gamepadButton.id)
                         .setButtonState(event.gamepadButton.button, event.gamepadButton.pressed);
                 break;
             case Event::Type::GamepadConnected:
@@ -124,7 +124,7 @@ namespace ecstasy::integration::event
 
                 if (registry.hasResource<Gamepads>())
                     registry.getResource<Gamepads>()
-                        .get(event.gamepadConnected.id)
+                        ->get(event.gamepadConnected.id)
                         .setConnected(event.gamepadConnected.connected);
                 break;
             case Event::Type::GamepadAxis:
@@ -132,7 +132,7 @@ namespace ecstasy::integration::event
 
                 if (registry.hasResource<Gamepads>())
                     registry.getResource<Gamepads>()
-                        .get(event.gamepadAxis.id)
+                        ->get(event.gamepadAxis.id)
                         .setAxisValue(event.gamepadAxis.axis, event.gamepadAxis.value);
                 break;
             default: break;
@@ -140,7 +140,7 @@ namespace ecstasy::integration::event
 
 #ifdef ECSTASY_INTEGRATIONS_USER_ACTION
         if (registry.hasResource<user_action::Users>())
-            registry.getResource<user_action::Users>().handleEvent(registry, event);
+            registry.getResource<const user_action::Users>()->handleEvent(registry, event);
 #endif
     }
 } // namespace ecstasy::integration::event

--- a/src/ecstasy/integrations/event/inputs/Gamepads.hpp
+++ b/src/ecstasy/integrations/event/inputs/Gamepads.hpp
@@ -23,7 +23,7 @@ namespace ecstasy::integration::event
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-11-18)
     ///
-    class Gamepads : public ecstasy::Resource {
+    class Gamepads : public ecstasy::Resource<Gamepads> {
       public:
         /// @brief Number of supported gamepads.
         static const size_t GamepadCount = 4;

--- a/src/ecstasy/integrations/event/inputs/Keyboard.hpp
+++ b/src/ecstasy/integrations/event/inputs/Keyboard.hpp
@@ -27,7 +27,7 @@ namespace ecstasy::integration::event
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-11-16)
     ///
-    class Keyboard : public Resource {
+    class Keyboard : public Resource<Keyboard> {
       public:
         // LCOV_EXCL_START
 

--- a/src/ecstasy/integrations/event/inputs/Mouse.hpp
+++ b/src/ecstasy/integrations/event/inputs/Mouse.hpp
@@ -27,7 +27,7 @@ namespace ecstasy::integration::event
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-11-04)
     ///
-    class Mouse : public Resource {
+    class Mouse : public Resource<Mouse> {
       public:
         // LCOV_EXCL_START
 

--- a/src/ecstasy/integrations/sfml/systems/PollEvents.cpp
+++ b/src/ecstasy/integrations/sfml/systems/PollEvents.cpp
@@ -64,10 +64,10 @@ namespace ecstasy::integration::sfml
     {
         if (!registry.hasResource<RenderWindow>())
             return;
-        RenderWindow &windowWrapper = registry.getResource<RenderWindow>();
+        RR<RenderWindow> windowWrapper = registry.getResource<RenderWindow>();
 
         sf::Event event;
-        while (windowWrapper.get().pollEvent(event)) {
+        while (windowWrapper->get().pollEvent(event)) {
             switch (event.type) {
                 /// Mouse events
                 case sf::Event::MouseButtonPressed:
@@ -117,7 +117,7 @@ namespace ecstasy::integration::sfml
                             event.joystickMove.position / 100.f));
                     break;
 
-                case sf::Event::Closed: windowWrapper.get().close(); break;
+                case sf::Event::Closed: windowWrapper->get().close(); break;
                 default: break;
             }
         }

--- a/src/ecstasy/integrations/user_action/PollActions.hpp
+++ b/src/ecstasy/integrations/user_action/PollActions.hpp
@@ -48,10 +48,10 @@ namespace ecstasy::integration::user_action
         {
             if (!registry.hasResource<PendingActions>())
                 return;
-            auto &pendingActions = registry.getResource<PendingActions>();
-            while (!pendingActions.get().empty()) {
-                std::ignore = std::make_tuple((callListeners<Actions>(registry, pendingActions.get().front()), 0)...);
-                pendingActions.get().pop();
+            RR<PendingActions> pendingActions = registry.getResource<PendingActions>();
+            while (!pendingActions->get().empty()) {
+                std::ignore = std::make_tuple((callListeners<Actions>(registry, pendingActions->get().front()), 0)...);
+                pendingActions->get().pop();
             }
         }
 

--- a/src/ecstasy/integrations/user_action/Users.cpp
+++ b/src/ecstasy/integrations/user_action/Users.cpp
@@ -27,7 +27,7 @@ namespace ecstasy::integration::user_action
     {
         if (!registry.hasResource<Users>())
             return;
-        registry.getResource<Users>().updateBindings();
+        registry.getResource<Users>()->updateBindings();
     }
 
     void Users::updateBindings()
@@ -61,7 +61,7 @@ namespace ecstasy::integration::user_action
     void Users::callActionListeners(Registry &registry, Action action)
     {
         if (registry.hasResource<PendingActions>())
-            registry.getResource<PendingActions>().get().push(action);
+            registry.getResource<PendingActions>()->get().push(action);
 
         for (auto [entity, maybeListener, maybeListeners] :
             registry.select<Entities, Maybe<ActionListener>, Maybe<ActionListeners>>()

--- a/src/ecstasy/integrations/user_action/Users.hpp
+++ b/src/ecstasy/integrations/user_action/Users.hpp
@@ -37,7 +37,7 @@ namespace ecstasy::integration::user_action
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-12-02)
     ///
-    class Users : public ecstasy::Resource {
+    class Users : public ecstasy::Resource<Users> {
       private:
         /// @brief Helper type instead of using @ref std::pair.
         /// Describe a link between an action and a user.

--- a/src/ecstasy/query/concepts/Queryable.hpp
+++ b/src/ecstasy/query/concepts/Queryable.hpp
@@ -198,6 +198,40 @@ namespace ecstasy::query
     using thread_safe_queryable_t = typename thread_safe_queryable<Q, ThreadSafe>::type;
 
     ///
+    /// @brief Get the reference type of a maybe thread safe type.
+    /// If @b ThreadSafe is true and @b T is @ref thread::Lockable, then the type is a @ref thread::LockableView<T>.
+    /// Otherwise, the type is a reference to the type @b T.
+    ///
+    /// @tparam T Type.
+    /// @tparam ThreadSafe Whether the type should be thread safe or not. Default to true.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-04-17)
+    ///
+    template <typename T, bool ThreadSafe>
+    struct thread_safe_reference {
+        using type = T &;
+    };
+
+    /// @copydoc thread_safe_reference
+    template <thread::Lockable T>
+    struct thread_safe_reference<T, true> {
+        using type = thread::LockableView<T>;
+    };
+
+    ///
+    /// @brief Alias for the reference type of a maybe thread safe type.
+    ///
+    /// @tparam T Type.
+    /// @tparam ThreadSafe Whether the type should be thread safe or not. Default to true.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-04-17)
+    ///
+    template <typename T, bool ThreadSafe = true>
+    using thread_safe_reference_t = typename thread_safe_reference<T, ThreadSafe>::type;
+
+    ///
     /// @brief Get the queryable type with the correct qualifiers.
     /// By default this is a reference to the type @b Q.
     /// If Q is @ref thread::Lockable and @b AutoLock is true, then the type is a @ref thread_safe_queryable_t<Q>. It is

--- a/src/ecstasy/registry/Registry.cpp
+++ b/src/ecstasy/registry/Registry.cpp
@@ -15,7 +15,7 @@
 namespace ecstasy
 {
     Registry::EntityBuilder::EntityBuilder(Registry &registry)
-        : _registry(registry), _builder(registry.getResource<Entities>().builder())
+        : _registry(registry), _builder(registry.getResource<Entities>()->builder())
     {
     }
 
@@ -35,24 +35,14 @@ namespace ecstasy
         return EntityBuilder(*this);
     }
 
-    const Entities &Registry::getEntities() const
-    {
-        return getResource<Entities>();
-    }
-
-    Entities &Registry::getEntities()
-    {
-        return getResource<Entities>();
-    }
-
     Entity Registry::getEntity(Entity::Index index) noexcept
     {
-        return getResource<Entities>().get(index);
+        return getResource<const Entities>()->get(index);
     }
 
     bool Registry::eraseEntity(Entity entity)
     {
-        bool erased = getResource<Entities>().erase(entity);
+        bool erased = getResource<Entities>()->erase(entity);
 
         if (!erased)
             return false;
@@ -62,7 +52,7 @@ namespace ecstasy
 
     size_t Registry::eraseEntities(std::span<Entity> entities)
     {
-        size_t erased = getResource<Entities>().erase(entities);
+        size_t erased = getResource<Entities>()->erase(entities);
 
         if (!erased)
             return 0;

--- a/src/ecstasy/registry/concepts/QueryableType.hpp
+++ b/src/ecstasy/registry/concepts/QueryableType.hpp
@@ -49,7 +49,7 @@ namespace ecstasy
     };
 
     /// @copydoc queryable_type
-    template <std::derived_from<Resource> R>
+    template <std::derived_from<ResourceBase> R>
         requires query::Queryable<R>
     struct queryable_type<R> {
         using type = R;

--- a/src/ecstasy/resources/ObjectWrapper.hpp
+++ b/src/ecstasy/resources/ObjectWrapper.hpp
@@ -25,7 +25,7 @@ namespace ecstasy
     /// @since 1.0.0 (2022-11-16)
     ///
     template <typename T>
-    class ObjectWrapper : public Resource {
+    class ObjectWrapper : public Resource<ObjectWrapper<T>> {
       public:
         ///
         /// @brief Construct a new Object Wrapper.

--- a/src/ecstasy/resources/Resource.hpp
+++ b/src/ecstasy/resources/Resource.hpp
@@ -26,14 +26,41 @@ namespace ecstasy
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-17)
     ///
-    class Resource
+    class ResourceBase
 #ifdef ECSTASY_LOCKABLE_RESOURCES
         : public thread::SharedRecursiveMutex
 #endif
     {
       public:
         /// @brief Default destructor.
-        virtual ~Resource() = default;
+        virtual ~ResourceBase() = default;
+    }; // namespace ecstasy
+
+    ///
+    /// @brief Resource class.
+    /// This class is templated to allow compatibility with LockableView.
+    ///
+    /// @tparam R Type of the resource.
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-04-17)
+    ///
+    template <typename R>
+    class Resource : public ResourceBase {
+      public:
+        ///
+        /// @brief Compatibility for LockableView. Using -> on a Resource or a LockableView will return the pointer to
+        /// the resource.
+        ///
+        /// @return R* Pointer to the resource.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-04-17)
+        ///
+        R *operator->()
+        {
+            return this;
+        }
     };
 } // namespace ecstasy
 

--- a/src/ecstasy/resources/entity/Entities.hpp
+++ b/src/ecstasy/resources/entity/Entities.hpp
@@ -27,7 +27,7 @@ namespace ecstasy
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-10-18)
     ///
-    class Entities : public Resource {
+    class Entities : public Resource<Entities> {
       public:
         ///
         /// @brief Entities builder to add multiple component to an entity on creation.

--- a/tests/registry/tests_DeletionStack.cpp
+++ b/tests/registry/tests_DeletionStack.cpp
@@ -25,10 +25,10 @@ TEST(DeletionStack, basic_cases)
 
     /// No deletion
     {
-        GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("1111111111"));
+        GTEST_ASSERT_EQ(registry.getEntities()->getMask(), util::BitSet("1111111111"));
         ecstasy::DeletionStack delStack(registry);
     }
-    GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("1111111111"));
+    GTEST_ASSERT_EQ(registry.getEntities()->getMask(), util::BitSet("1111111111"));
 
     {
         ecstasy::DeletionStack delStack(registry);
@@ -38,11 +38,11 @@ TEST(DeletionStack, basic_cases)
             if (++i % 2 == 0)
                 delStack.push(entity);
             /// Even if entity was marked for deletion it is still alive while the delStack isn't destroyed.
-            GTEST_ASSERT_TRUE(registry.getEntities().isAlive(entity));
+            GTEST_ASSERT_TRUE(registry.getEntities()->isAlive(entity));
         }
-        GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("1111111111"));
+        GTEST_ASSERT_EQ(registry.getEntities()->getMask(), util::BitSet("1111111111"));
         GTEST_ASSERT_EQ(delStack.size(), 5);
     }
     /// delStack deleted and so are the entities
-    GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("0101010101"));
+    GTEST_ASSERT_EQ(registry.getEntities()->getMask(), util::BitSet("0101010101"));
 }

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -55,7 +55,7 @@ class B : public ecstasy::ISystem {
     }
 };
 
-struct Counter : public ecstasy::Resource {
+struct Counter : public ecstasy::Resource<Counter> {
     int value;
 
     Counter(int initial = 0)
@@ -177,8 +177,8 @@ TEST(Registry, resources)
     /// Add resource with an initial value of 5 and add one
     registry.addResource<Counter>(5).count();
     ASSERT_TRUE(registry.hasResource<Counter>());
-    EXPECT_EQ(registry.getResource<Counter>().value, 6);
-    EXPECT_EQ(cregistry.getResource<Counter>().value, 6);
+    EXPECT_EQ(registry.getResource<Counter>()->value, 6);
+    EXPECT_EQ(cregistry.getResource<Counter>()->value, 6);
 
     /// Try to add resource already present
     EXPECT_THROW(registry.addResource<Counter>(), std::logic_error);
@@ -244,19 +244,19 @@ TEST(Registry, eraseEntity)
 
     for (int i = 0; i < 10; i++)
         registry.entityBuilder().with<Position>(1, 2).with<Size>(3, 4).build();
-    GTEST_ASSERT_EQ(cregistry.getEntities().getMask(), util::BitSet("1111111111"));
+    GTEST_ASSERT_EQ(cregistry.getEntities()->getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_EQ(registry.getStorage<Position>().getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_EQ(registry.getStorage<Size>().getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_TRUE(registry.eraseEntity(registry.getEntity(1)));
     GTEST_ASSERT_FALSE(registry.eraseEntity(registry.getEntity(1)));
     GTEST_ASSERT_TRUE(registry.eraseEntity(registry.getEntity(5)));
-    GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("1111011101"));
+    GTEST_ASSERT_EQ(registry.getEntities()->getMask(), util::BitSet("1111011101"));
     GTEST_ASSERT_EQ(registry.getStorage<Position>().getMask(), util::BitSet("1111011101"));
     GTEST_ASSERT_EQ(registry.getStorage<Size>().getMask(), util::BitSet("1111011101"));
 
-    GTEST_ASSERT_TRUE(cregistry.getEntities().isAlive(registry.getEntity(0)));
-    GTEST_ASSERT_FALSE(registry.getEntities().isAlive(registry.getEntity(1)));
-    GTEST_ASSERT_FALSE(registry.getEntities().isAlive(registry.getEntity(5)));
+    GTEST_ASSERT_TRUE(cregistry.getEntities()->isAlive(registry.getEntity(0)));
+    GTEST_ASSERT_FALSE(registry.getEntities()->isAlive(registry.getEntity(1)));
+    GTEST_ASSERT_FALSE(registry.getEntities()->isAlive(registry.getEntity(5)));
 }
 
 TEST(Registry, eraseEntities)
@@ -266,19 +266,19 @@ TEST(Registry, eraseEntities)
 
     for (int i = 0; i < 10; i++)
         registry.entityBuilder().with<Position>(1, 2).with<Size>(3, 4).build();
-    GTEST_ASSERT_EQ(cregistry.getEntities().getMask(), util::BitSet("1111111111"));
+    GTEST_ASSERT_EQ(cregistry.getEntities()->getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_EQ(registry.getStorage<Position>().getMask(), util::BitSet("1111111111"));
     GTEST_ASSERT_EQ(registry.getStorage<Size>().getMask(), util::BitSet("1111111111"));
     ecstasy::Entity toDelete[] = {registry.getEntity(1), registry.getEntity(5)};
     GTEST_ASSERT_EQ(registry.eraseEntities(std::span(toDelete)), 2);
     GTEST_ASSERT_EQ(registry.eraseEntities(std::span(toDelete)), 0);
-    GTEST_ASSERT_EQ(registry.getEntities().getMask(), util::BitSet("1111011101"));
+    GTEST_ASSERT_EQ(registry.getEntities()->getMask(), util::BitSet("1111011101"));
     GTEST_ASSERT_EQ(registry.getStorage<Position>().getMask(), util::BitSet("1111011101"));
     GTEST_ASSERT_EQ(registry.getStorage<Size>().getMask(), util::BitSet("1111011101"));
 
-    GTEST_ASSERT_TRUE(cregistry.getEntities().isAlive(registry.getEntity(0)));
-    GTEST_ASSERT_FALSE(registry.getEntities().isAlive(registry.getEntity(1)));
-    GTEST_ASSERT_FALSE(registry.getEntities().isAlive(registry.getEntity(5)));
+    GTEST_ASSERT_TRUE(cregistry.getEntities()->isAlive(registry.getEntity(0)));
+    GTEST_ASSERT_FALSE(registry.getEntities()->isAlive(registry.getEntity(1)));
+    GTEST_ASSERT_FALSE(registry.getEntities()->isAlive(registry.getEntity(5)));
 }
 
 TEST(Registry, EntityBuilder)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Return LockableView when requesting registry resource to lock the resource used.
This can be enabled/disabled with the **ECSTASY_AUTO_LOCK_RESOURCES** compilation option.

<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

Close #133

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] New tests written
- [x] Existing tests updated
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
