### PR TITLE
Fix Resource arrow operator missing const and dynamic cast

### DIFF
--- a/src/ecstasy/resources/Resource.hpp
+++ b/src/ecstasy/resources/Resource.hpp
@@ -59,7 +59,13 @@ namespace ecstasy
         ///
         R *operator->()
         {
-            return this;
+            return dynamic_cast<R *>(this);
+        }
+
+        /// @copydoc Resource::operator->()
+        const R *operator->() const
+        {
+            return dynamic_cast<const R *>(this);
         }
     };
 } // namespace ecstasy


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Arrow operator was missing a dynamic cast, failing implicit conversions.
And const version of arrow operator was also missing.

<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] New tests written
- [ ] Existing tests updated
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
