### PR TITLE
Introduce withRegistry helper in EntityBuilder

### DIFF
--- a/src/ecstasy/registry/Registry.hpp
+++ b/src/ecstasy/registry/Registry.hpp
@@ -508,6 +508,29 @@ namespace ecstasy
                 return *this;
             }
 
+
+            /// @brief Add a component to the builder target entity, forwarding the registry as first constructor parameter.
+            ///
+            /// @tparam C Component type.
+            /// @tparam Args Type of the Component constructor parameters
+            ///
+            /// @param[in] args Arguments to forward to the component constructor.
+            ///
+            /// @return EntityBuilder& @b this.
+            ///
+            /// @throw std::logic_error If the builder was already consumed or if the entity already has the
+            /// component.
+            ///
+            /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+            /// @since 1.0.0 (2024-08-27)
+            ///
+            template <typename C, typename... Args>
+            EntityBuilder &withRegistry(Args &&...args)
+            {
+                _builder.with(_registry.getStorageSafe<C>(), _registry, std::forward<Args>(args)...);
+                return *this;
+            }
+
             ///
             /// @brief Add a component to the builder target entity.
             ///
@@ -547,6 +570,30 @@ namespace ecstasy
             const Entity &getEntity() const
             {
                 return _builder.getEntity();
+            }
+
+            /// @brief Get a const reference to the registry.
+            ///
+            /// @return const Registry& Const reference to the registry
+            ///
+            /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+            /// @since 1.0.0 (2024-08-27)
+            ///
+            constexpr const Registry &getRegistry() const
+            {
+                return _registry;
+            }
+
+            /// @brief Get a reference to the registry.
+            ///
+            /// @return Registry& reference to the registry
+            ///
+            /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+            /// @since 1.0.0 (2024-08-27)
+            ///
+            constexpr Registry &getRegistry()
+            {
+                return _registry;
             }
 
           private:

--- a/tests/registry/tests_Registry.cpp
+++ b/tests/registry/tests_Registry.cpp
@@ -99,6 +99,14 @@ struct Position {
     }
 };
 
+struct NeedRegistry {
+    const ecstasy::Registry &registry;
+
+    NeedRegistry(const ecstasy::Registry &aRegistry) : registry(aRegistry)
+    {
+    }
+};
+
 struct Velocity {
     Vector2i v;
 
@@ -290,23 +298,32 @@ TEST(Registry, EntityBuilder)
 {
     ecstasy::Registry registry;
 
-    /// Build the entity
-    ecstasy::Registry::EntityBuilder builder = registry.entityBuilder();
-    builder.with<Position>(1, 2).with<Velocity>(3, 4).with<Size>(4, 5).with<std::vector<int>>({1, 2, 3, 4, 5, 6});
-    EXPECT_THROW(builder.with<Position>(42, 84), std::logic_error);
-    ecstasy::RegistryEntity e(builder.build(), registry);
+    {
+        /// Build the entity
+        ecstasy::Registry::EntityBuilder builder = registry.entityBuilder();
+        builder.with<Position>(1, 2).with<Velocity>(3, 4).with<Size>(4, 5).with<std::vector<int>>({1, 2, 3, 4, 5, 6});
+        EXPECT_THROW(builder.with<Position>(42, 84), std::logic_error);
+        ecstasy::RegistryEntity e(builder.build(), registry);
 
-    /// Mess with the builder after build done
-    EXPECT_THROW(builder.with<Vector2i>(5, 2), std::logic_error);
-    EXPECT_THROW(builder.build(), std::logic_error);
+        /// Mess with the builder after build done
+        EXPECT_THROW(builder.with<Vector2i>(5, 2), std::logic_error);
+        EXPECT_THROW(builder.build(), std::logic_error);
 
-    /// Test if entity has all attached components
-    EXPECT_TRUE(e.has<Position>());
-    EXPECT_TRUE(e.has<Velocity>());
-    EXPECT_TRUE(e.has<Size>());
-    EXPECT_TRUE(e.has<std::vector<int>>());
-    EXPECT_EQ(e.get<std::vector<int>>().size(), 6);
-    EXPECT_FALSE(e.has<Vector2i>());
+        /// Test if entity has all attached components
+        EXPECT_TRUE(e.has<Position>());
+        EXPECT_TRUE(e.has<Velocity>());
+        EXPECT_TRUE(e.has<Size>());
+        EXPECT_TRUE(e.has<std::vector<int>>());
+        EXPECT_EQ(e.get<std::vector<int>>().size(), 6);
+        EXPECT_FALSE(e.has<Vector2i>());
+    }
+
+    {
+        /// Use withRegistry
+        ecstasy::Registry::EntityBuilder builder = registry.entityBuilder();
+        ecstasy::RegistryEntity e(builder.withRegistry<NeedRegistry>().build(), builder.getRegistry());
+        EXPECT_EQ(&e.get<NeedRegistry>().registry, &registry);
+    }
 }
 
 TEST(Registry, functionnal)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Expose `EntityBuilder._registry` with const and non const `getRegistry` methods.
And introduce a new `withRegistry` helper to forward the internal registry as the first parameter to the component constructor.

<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [x] New tests written
- [ ] Existing tests updated
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
