### PR TITLE
Introduce new esf::EventListener

### DIFF
--- a/src/ecstasy/integrations/sfml/demo/02_events/main.cpp
+++ b/src/ecstasy/integrations/sfml/demo/02_events/main.cpp
@@ -99,6 +99,10 @@ int main(int argc, char **argv)
     ecstasy::Registry registry;
     esf::RenderWindow &window =
         registry.addResource<esf::RenderWindow>(sf::VideoMode(1280, 720), "ECSTASY SFML integration: events");
+    window.setEventListener([](const sf::Event &event) {
+        std::cout << "Event " << event.type << std::endl;
+        return false;
+    });
     registry.addSystem<esf::PollEvents>();
     (void)argv;
     (void)argc;

--- a/src/ecstasy/integrations/sfml/resources/RenderWindow.hpp
+++ b/src/ecstasy/integrations/sfml/resources/RenderWindow.hpp
@@ -13,18 +13,93 @@
 #define ECSTASY_INTEGRATIONS_SFML_RESOURCES_RENDERWINDOW_HPP_
 
 #include <SFML/Graphics/RenderWindow.hpp>
+#include <functional>
 
 #include "ecstasy/resources/ObjectWrapper.hpp"
 
 namespace ecstasy::integration::sfml
 {
+
+    ///
+    /// @brief Event listener type.
+    ///
+    /// @param[in] event Event to handle.
+    /// @return true If the event was handled (ie must not be processed anymore).
+    ///
+    /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+    /// @since 1.0.0 (2024-09-26)
+    ///
+    using EventListener = std::function<bool(const sf::Event &)>;
+
     ///
     /// @brief SFML RenderWindow wrapper.
     ///
     /// @author Andréas Leroux (andreas.leroux@epitech.eu)
     /// @since 1.0.0 (2022-11-16)
     ///
-    using RenderWindow = ecstasy::ObjectWrapper<sf::RenderWindow>;
+    class RenderWindow : public ecstasy::ObjectWrapper<sf::RenderWindow> {
+      public:
+        ///
+        /// @brief Construct a new Render Window.
+        ///
+        /// @tparam Args Argument types of the object constructor.
+        ///
+        /// @param[in] args Arguments of the object constructor.
+        ///
+        template <typename... Args>
+        RenderWindow(Args &&...args)
+            : ecstasy::ObjectWrapper<sf::RenderWindow>(std::forward<Args>(args)...), _eventListener(nullptr)
+        {
+        }
+
+        ///
+        /// @brief Destroy the Render Window.
+        ///
+        ~RenderWindow() = default;
+
+        ///
+        /// @brief Set the event listener.
+        ///
+        /// @param[in] listener Event listener.
+        ///
+        void setEventListener(EventListener listener)
+        {
+            _eventListener = listener;
+        }
+
+        ///
+        /// @brief Get the Event Listener
+        ///
+        /// @return constexpr EventListener& Event listener.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2024-09-26)
+        ///
+        constexpr EventListener &getEventListener()
+        {
+            return _eventListener;
+        }
+
+        ///
+        /// @brief Poll the next event.
+        ///
+        /// @param[out] event Event to fill.
+        ///
+        /// @return true If an event was polled.
+        ///
+        bool pollEvent(sf::Event &event)
+        {
+            while (_object.pollEvent(event)) {
+                // Return true if a usable (ie not stoled by the listener) event was polled
+                if (!_eventListener || (!_eventListener(event)))
+                    return true;
+            }
+            return false;
+        }
+
+      private:
+        EventListener _eventListener;
+    };
 } // namespace ecstasy::integration::sfml
 
 #endif /* !ECSTASY_INTEGRATIONS_SFML_RESOURCES_RENDERWINDOW_HPP_ */

--- a/src/ecstasy/integrations/sfml/systems/PollEvents.cpp
+++ b/src/ecstasy/integrations/sfml/systems/PollEvents.cpp
@@ -67,7 +67,7 @@ namespace ecstasy::integration::sfml
         RR<RenderWindow> windowWrapper = registry.getResource<RenderWindow>();
 
         sf::Event event;
-        while (windowWrapper->get().pollEvent(event)) {
+        while (windowWrapper->pollEvent(event)) {
             switch (event.type) {
                 /// Mouse events
                 case sf::Event::MouseButtonPressed:

--- a/src/ecstasy/resources/ObjectWrapper.hpp
+++ b/src/ecstasy/resources/ObjectWrapper.hpp
@@ -76,7 +76,7 @@ namespace ecstasy
             return _object;
         }
 
-      private:
+      protected:
         T _object;
     };
 } // namespace ecstasy


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Introduce a new `esf::EventListener` in the `esf::RenderWindow`.

The listener is called when the `RenderWindow.pollEvent` is called, like in the `esf::PollEvents` system.

Example usage:
```cpp
esf::RenderWindow &window =
    registry.addResource<esf::RenderWindow>(sf::VideoMode(1280, 720), "ECSTASY SFML integration: events");
window.setEventListener([&registry](const sf::Event &event) {
    std::cout << "Event " << event.type << std::endl;
    return false;
});
registry.addSystem<esf::PollEvents>();
```


<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] New tests written
- [ ] Existing tests updated
- [x] Functionnal demo updated as a test
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
