### PR TITLE
Disable codecov if PR head and base are different or CODECOV_TOKEN not set

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -92,7 +92,7 @@ jobs:
           gcovr -r ${{github.workspace}}  --exclude-unreachable-branches --exclude-throw-branches --xml --output ./coverage.xml -e "src/ecstasy/integrations/sfml/*" ${{github.workspace}}/build/src
 
       - name: Upload Coverage Data
-        if: matrix.GCOV
+        if: matrix.GCOV && (secrets.CODECOV_TOKEN != '') && (github.event_name == 'push'  || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

The CI should not fail anymore when running PR from forks toward this repository, the codecov action will be skipped.
It would have been better to always run but  doesn't seem possible for security reason (https://github.com/codecov/codecov-action/issues/29)

It should still work on fork if they set their own CODECOV_TOKEN secret.

<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

Close #169


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## [optional] Minor fixes

<!--
If you ran accross some minor bugs and fixed them please list them below and explain what was the issue (what/when was happening and why).
If there is no minor fixes feel free to delete this section.
-->

## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [ ] New tests written
- [ ] Existing tests updated
- [x] Tests are not required because this is a CI update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
