### PR TITLE
Fix crash when running JsonSerializer::closeNested() while in write mode

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -60,7 +60,7 @@ jobs:
           curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
           sudo apt-get update
-          sudo apt-get install -y ninja-build clang-14 libc++-14-dev libc++abi-14-dev libstdc++-11-dev
+          sudo apt-get install -y ninja-build clang-15 libc++-14-dev libc++abi-14-dev libstdc++-11-dev libfreetype-dev
           echo "CXXFLAGS=${{matrix.compiler.CXXFLAGS}}" >> $GITHUB_ENV
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.compiler, 'Clang')
 

--- a/src/ecstasy/serialization/JsonSerializer.hpp
+++ b/src/ecstasy/serialization/JsonSerializer.hpp
@@ -443,7 +443,7 @@ namespace ecstasy::serialization
         ///
         JsonSerializer &closeNested()
         {
-            if (_stack.top().get().IsArray())
+            if (_stack.top().get().IsArray() && !_arrayIterators.empty())
                 _arrayIterators.pop();
             _stack.pop();
             return *this;
@@ -496,6 +496,45 @@ namespace ecstasy::serialization
                 cursor.PushBack(value, _document.GetAllocator());
             }
             return *this;
+        }
+
+        ///
+        /// @brief Check if the current cursor is at the end of an array.
+        ///
+        /// @return bool True if the cursor is at the end of an array, false otherwise.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2025-04-10)
+        ///
+        bool isArrayEnd()
+        {
+            rapidjson::Value &cursor = getWriteCursor();
+
+            if (!cursor.IsArray()) {
+                throw std::invalid_argument("Invalid cursor type. Expected object or array.");
+            }
+            // If the array is empty, push the first element (first document element)
+            if (_arrayIterators.empty())
+                _arrayIterators.push(cursor.Begin());
+            return _arrayIterators.top() == cursor.End();
+        }
+
+        ///
+        /// @brief Get the size of the current array.
+        ///
+        /// @return size_t Size of the current array.
+        ///
+        /// @author Andréas Leroux (andreas.leroux@epitech.eu)
+        /// @since 1.0.0 (2025-04-10)
+        ///
+        size_t getArraySize()
+        {
+            rapidjson::Value &cursor = getWriteCursor();
+
+            if (!cursor.IsArray()) {
+                throw std::invalid_argument("Invalid cursor type. Expected object or array.");
+            }
+            return cursor.Size();
         }
 
       private:

--- a/tests/query/tests_Query.cpp
+++ b/tests/query/tests_Query.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <gtest/gtest.h>
 #include "ecstasy/query/Query.hpp"
 #include "ecstasy/resources/entity/Entities.hpp"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

FIx a crash occuring when calling JsonSerializer::closeNested() while writing data to the serializer due to a missing verification.

Also introduce new `isArrayEnd` and `getArraySize` helper methods.

<!--
Add link to tickets if any like this:
Close #42
Related #84
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Added/updated tests?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->

- [x] Didn't had the time to write them, and I am the maintainer
- [ ] New tests written
- [ ] Existing tests updated
- [ ] Tests are not required because this is a documentation update <!-- Update to appropriate reason -->
- [ ] I need help with writing tests
